### PR TITLE
Delete comments over API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ typings/
 # dotenv environment variables file
 .env
 .env.test
+docker-compose.env
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/AzureCommentsApiDelete/function.json
+++ b/AzureCommentsApiDelete/function.json
@@ -1,0 +1,21 @@
+{
+    "bindings": [
+      {
+        "authLevel": "anonymous",
+        "type": "httpTrigger",
+        "direction": "in",
+        "name": "req",
+        "methods": [
+          "delete"
+        ],
+        "route": "comments/{commentId}"
+      },
+      {
+        "type": "http",
+        "direction": "out",
+        "name": "res"
+      }
+    ],
+    "scriptFile": "../build/AzureCommentsApiDelete/index.js"
+  }
+  

--- a/AzureCommentsApiDelete/index.ts
+++ b/AzureCommentsApiDelete/index.ts
@@ -25,8 +25,11 @@ const commentsApi: AzureFunction = async function (context: Context, req: HttpRe
   }
 
   const forDate = new Date()
+  console.log(`Date: ${forDate}`)
+
   const signatureVerificationResult = await authService.isHmacSignatureValid(
-    req,
+    'DELETE',
+    `/comments/${commentId}`,
     300,
     accountId,
     timestamp,
@@ -40,6 +43,15 @@ const commentsApi: AzureFunction = async function (context: Context, req: HttpRe
     context.log.warn(`Request too old: ${Math.abs(now - parseInt(timestamp))}s`)
     context.res = {
       status: 429,
+    }
+
+    return
+  }
+
+  if (signatureVerificationResult !== HmacValidationResult.OK) {
+    context.log.warn(`Invalid signature: ${signatureVerificationResult}`)
+    context.res = {
+      status: 403,
     }
 
     return

--- a/AzureCommentsApiDelete/index.ts
+++ b/AzureCommentsApiDelete/index.ts
@@ -25,7 +25,6 @@ const commentsApi: AzureFunction = async function (context: Context, req: HttpRe
   }
 
   const forDate = new Date()
-  console.log(`Date: ${forDate}`)
 
   const signatureVerificationResult = await authService.isHmacSignatureValid(
     'DELETE',

--- a/AzureCommentsApiDelete/index.ts
+++ b/AzureCommentsApiDelete/index.ts
@@ -1,0 +1,56 @@
+import _ from 'lodash'
+import { appContext } from '../src/azure'
+import { AzureFunction, Context, HttpRequest } from '@azure/functions'
+import { CommentService } from '../src/shared/comments/comment.service'
+import { AuthService, HmacValidationResult } from '../src/shared/auth/auth.service'
+
+const commentsApi: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
+  context.log.info('HTTP trigger function processing a request to delete a comment')
+
+  const app = await appContext()
+  const authService = app.get(AuthService)
+  const commentService = app.get(CommentService)
+  const timestamp = req.headers['x-timestamp'] as string
+  const providedSignature = req.headers['x-signature'] as string
+  const accountId = req.headers['x-account-id'] as string
+  const commentId = req.params.commentId
+
+  if (!timestamp || !providedSignature || !accountId) {
+    context.log.warn('Missing auth headers :(')
+    context.res = {
+      status: 400,
+    }
+
+    return
+  }
+
+  const forDate = new Date()
+  const signatureVerificationResult = await authService.isHmacSignatureValid(
+    req,
+    300,
+    accountId,
+    timestamp,
+    providedSignature,
+    forDate
+  )
+
+  // Verify the request is not too old (e.g., 5 minutes)
+  if (signatureVerificationResult === HmacValidationResult.REQUEST_TOO_OLD) {
+    const now = Math.floor(forDate.getTime() / 1000)
+    context.log.warn(`Request too old: ${Math.abs(now - parseInt(timestamp))}s`)
+    context.res = {
+      status: 429,
+    }
+
+    return
+  }
+
+  await commentService.deleteSingleById(commentId)
+  context.log.info(`Deleted comment ${commentId}`)
+
+  context.res = {
+    status: 201,
+  }
+}
+
+export default commentsApi

--- a/AzureCommentsNotify/index.ts
+++ b/AzureCommentsNotify/index.ts
@@ -15,7 +15,11 @@ const commentEventHandler: AzureFunction = async function (context: Context, eve
   const configService = app.get(ConfigService)
   const emailService = app.get(EmailService)
   const { account, comment } = eventBody
-  const email = emailService.notifyOnSingleComment(comment, `${configService.adminUrl()}/dashboard`)
+  const commentEntity = {
+    ...comment,
+    postedAt: new Date(comment.postedAt),
+  }
+  const email = emailService.notifyOnSingleComment(commentEntity, `${configService.adminUrl()}/dashboard`)
   context.log(`Notifying ${account.email} on comment posted`)
 
   await sendMailService.send(configService.mailgunSender(), account.email, email.subject, email.html, email.text)

--- a/asyncApi.yaml
+++ b/asyncApi.yaml
@@ -54,13 +54,21 @@ components:
         comment:
           type: object
           required:
+            - id
             - postUrl
+            - postedAt
             - text
             - author
           additionalProperties: false
           properties:
+            id: 
+              type: string
+              format: guid
             postUrl:
               type: string
+            postedAt:
+              type: string
+              format: datetime
             postTitle:
               type: string
             text:

--- a/docker-compose.env.example
+++ b/docker-compose.env.example
@@ -1,0 +1,4 @@
+# Set these and align with what you put in .env
+POSTGRES_DB=
+POSTGRES_USER=
+POSTGRES_PASSWORD=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,12 +27,13 @@ services:
 
   db:
     image: postgres:14-alpine
+    hostname: db
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_DB: master
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     networks:
       - my_network
     volumes:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   },
   "scripts": {
     "generate": "json2ts -i schemas/**/* -o generated/ && ts-auto-guard --paths ./generated/*.ts --export-all && ts-auto-guard --paths ./src/**/*.interface.ts --export-all",
+    "build": "tsc -p tsconfig.json",
+    "watch": "tsc -p tsconfig.json -w",
     "api": "ts-node src/api.ts",
     "web": "ts-node src/web.ts",
     "cli": "ts-node src/cli.ts",
@@ -14,7 +16,6 @@
     "test": "jest",
     "build:sass": "node-sass assets/scss -o public/css  --output-style compressed",
     "prebuild": "yarn generate",
-    "build": "tsc -p tsconfig.json",
     "postbuild": "copyfiles \"./src/**/*.hbs\" \"./public/**/*\" \"./public/assets/**/*\" build",
     "clean": "rm -rf build && rm -rf generated",
     "ts-node": "ts-node",
@@ -25,7 +26,6 @@
     "prestart": "node ./build/src/cli.js db:migrate",
     "start": "node ./build/src/web.js",
     "start-api": "node ./build/src/api.js",
-    "watch": "tsc -p tsconfig.json -w",
     "func": "func start --verbose",
     "zip:app": "zip -q -r webapp.zip . -x@.appserviceignore -x .appserviceignore",
     "zip:api": "zip -q -r funcapp.zip . -x@.funcignore -x .funcignore"

--- a/scripts/rmcomment.sh
+++ b/scripts/rmcomment.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# Configuration
+missing_vars=()
+
+if [ -z "${API_SECRET_KEY}" ]; then
+    missing_vars+=("API_SECRET_KEY")
+fi
+
+if [ -z "${API_BASE_URL}" ]; then
+    missing_vars+=("API_BASE_URL")
+fi
+
+if [ -z "${ACCOUNT_ID}" ]; then
+    missing_vars+=("ACCOUNT_ID")
+fi
+
+if [ ${#missing_vars[@]} -ne 0 ]; then
+    echo "Error: Required environment variables are not set:"
+    printf '  %s\n' "${missing_vars[@]}"
+    echo ""
+    echo "Please set them first:"
+    echo "  export API_SECRET_KEY='your-secret-key-here'"
+    echo "  export API_BASE_URL='https://your-function-app.azurewebsites.net'"
+    echo "  export ACCOUNT_ID='your-account-id-here'"
+    exit 1
+fi
+
+# Function to create HMAC signature
+create_signature() {
+    local method="$1"
+    local url_path="$2"
+    local timestamp="$3"
+    
+    # Create string to sign (same format as server)
+    local string_to_sign="${method}\n${url_path}\n${timestamp}"
+    
+    # Create HMAC signature using sha256
+    echo -en "$string_to_sign" | openssl dgst -sha256 -hmac "$API_SECRET_KEY" -hex | sed 's/^.* //'
+}
+
+# Function to delete an item
+delete_item() {
+    local item_id="$1"
+    
+    if [ -z "$item_id" ]; then
+        echo "Error: Item ID is required"
+        echo "Usage: $0 delete <item-id>"
+        exit 1
+    fi
+    
+    # Create timestamp (seconds since epoch)
+    local timestamp=$(date +%s)
+    
+    # Construct the URL path (must match what's used in signature)
+    local url_path="/comments/${item_id}"
+    
+    # Generate signature
+    local signature=$(create_signature "DELETE" "$url_path" "$timestamp")
+    
+    # Make the DELETE request using curl
+    response=$(curl -s -w "\n%{http_code}" \
+        -X DELETE \
+        -H "x-timestamp: ${timestamp}" \
+        -H "x-signature: ${signature}" \
+        -H "x-account-id: ${ACCOUNT_ID}" \
+        "${API_BASE_URL}${url_path}")
+    
+    # Extract status code and body
+    http_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | sed '$d')
+    
+    # Handle response
+    if [ "$http_code" -eq 200 ]; then
+        echo "Successfully deleted item ${item_id}"
+        [ ! -z "$body" ] && echo "Response: $body"
+    else
+        echo "Error deleting item ${item_id}"
+        echo "Status code: ${http_code}"
+        [ ! -z "$body" ] && echo "Error: $body"
+        exit 1
+    fi
+}
+
+# Function to display help
+show_help() {
+    echo "Usage: $0 <command> [options]"
+    echo ""
+    echo "Commands:"
+    echo "  delete <item-id>    Delete an item by ID"
+    echo "  help               Show this help message"
+    echo ""
+    echo "Example:"
+    echo "  $0 delete 12345"
+}
+
+# Main script logic
+case "$1" in
+    delete)
+        delete_item "$2"
+        ;;
+    help|--help|-h)
+        show_help
+        ;;
+    *)
+        echo "Error: Unknown command '$1'"
+        echo ""
+        show_help
+        exit 1
+        ;;
+esac

--- a/src/api/api.queries.ts
+++ b/src/api/api.queries.ts
@@ -1,32 +1,27 @@
 /** Types generated for queries found in "src/api/api.sql" */
-import { PreparedQuery } from '@pgtyped/runtime'
+import { PreparedQuery } from '@pgtyped/runtime';
 
 /** 'LoginFromToken' parameters type */
 export interface ILoginFromTokenParams {
-  token: string | null | void
+  token?: string | null | void;
 }
 
 /** 'LoginFromToken' return type */
 export interface ILoginFromTokenResult {
-  created_at: Date
-  email: string
-  id: string
-  password: Buffer
-  username: string
+  created_at: Date;
+  email: string;
+  id: string;
+  password: Buffer;
+  username: string;
 }
 
 /** 'LoginFromToken' query type */
 export interface ILoginFromTokenQuery {
-  params: ILoginFromTokenParams
-  result: ILoginFromTokenResult
+  params: ILoginFromTokenParams;
+  result: ILoginFromTokenResult;
 }
 
-const loginFromTokenIR: any = {
-  usedParamSet: { token: true },
-  params: [{ name: 'token', required: false, transform: { type: 'scalar' }, locs: [{ a: 87, b: 92 }] }],
-  statement:
-    'SELECT DISTINCT a.* FROM accounts a JOIN tokens t ON (a.id=t.account_id) WHERE t.token=:token AND t.revoked_at IS NULL',
-}
+const loginFromTokenIR: any = {"usedParamSet":{"token":true},"params":[{"name":"token","required":false,"transform":{"type":"scalar"},"locs":[{"a":87,"b":92}]}],"statement":"SELECT DISTINCT a.* FROM accounts a JOIN tokens t ON (a.id=t.account_id) WHERE t.token=:token AND t.revoked_at IS NULL"};
 
 /**
  * Query generated from SQL:
@@ -34,4 +29,6 @@ const loginFromTokenIR: any = {
  * SELECT DISTINCT a.* FROM accounts a JOIN tokens t ON (a.id=t.account_id) WHERE t.token=:token AND t.revoked_at IS NULL
  * ```
  */
-export const loginFromToken = new PreparedQuery<ILoginFromTokenParams, ILoginFromTokenResult>(loginFromTokenIR)
+export const loginFromToken = new PreparedQuery<ILoginFromTokenParams,ILoginFromTokenResult>(loginFromTokenIR);
+
+

--- a/src/api/comments.controller.ts
+++ b/src/api/comments.controller.ts
@@ -82,12 +82,19 @@ export class CommentsController {
       return
     }
 
+    const commentEntity = await this.commentsService.findById(account, result as string)
+    if (!commentEntity) {
+      this.logger.warn(`Comment ${result} not found - cannot send email notification`)
+  
+      return
+    }
+
     try {
       const emailSettings = await this.accountService.emailSettingsFor(account)
       if (emailSettings?.notifyOnComments) {
         // notify
         this.logger.log('Scheduling an email notification about a new comment')
-        this.jobQueue.publish({ account, comment })
+        this.jobQueue.publish({ account, comment: commentEntity })
       }
     } catch (oops) {
       this.logger.warn(`Trouble scheduling email notification: ${(oops as Error)?.message}`)

--- a/src/api/comments.controller.ts
+++ b/src/api/comments.controller.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import { Account } from '../shared/accounts/account.interface'
 import { AccountService } from '../shared/accounts/account.service'
-import { Body, Controller, Get, HttpStatus, Inject, Post, Req, Res } from '@nestjs/common'
+import { Body, Delete, Controller, Get, HttpStatus, Inject, Post, Req, Res, Param } from '@nestjs/common'
 import { CommentDto, CommentWithId } from '../shared/comments/comment.interface'
 import { CommentCreatedResult, CommentService, SortOrder } from '../shared/comments/comment.service'
 import { ContentFilteringService } from '../shared/comments/content-filtering-service'
@@ -92,5 +92,13 @@ export class CommentsController {
     } catch (oops) {
       this.logger.warn(`Trouble scheduling email notification: ${(oops as Error)?.message}`)
     }
+  }
+
+  @Delete(':commentId')
+  async deleteComment(@Param('commentId') commentId: string, @Res() res: Response): Promise<void> {
+    // TODO add HMAC auth as we'll call this from the CLI
+    this.logger.log(`Deleting comment ${commentId}`)
+    await this.commentsService.deleteSingleById(commentId)
+    res.status(HttpStatus.OK).send()
   }
 }

--- a/src/api/login.middleware.ts
+++ b/src/api/login.middleware.ts
@@ -58,8 +58,10 @@ export class HmacLoginMiddleware implements NestMiddleware {
       }
 
       const forDate = new Date()
+      console.log(`Date: ${forDate}`)
       const signatureVerificationResult = await this.authService.isHmacSignatureValid(
-        req,
+        'DELETE',
+        req.url, // gonna be relative - /comments/123
         300,
         accountId,
         timestamp,
@@ -77,7 +79,7 @@ export class HmacLoginMiddleware implements NestMiddleware {
       }
       
       // see if at least one token matches the signature
-      if (signatureVerificationResult === HmacValidationResult.INVALID_SIGNATURE) {
+      if (signatureVerificationResult !== HmacValidationResult.OK) {
         this.logger.warn(`Invalid signature`)
         res.status(403).end()
 

--- a/src/api/login.middleware.ts
+++ b/src/api/login.middleware.ts
@@ -2,11 +2,11 @@ import _ from 'lodash'
 import { Injectable, NestMiddleware } from '@nestjs/common'
 import { Request, Response, NextFunction } from 'express'
 import { Logger } from 'nestjs-pino'
-import { AuthService } from '../shared/auth/auth.service'
+import { AuthService, HmacValidationResult } from '../shared/auth/auth.service'
 import { isAccount } from '../shared/accounts/account.interface.guard'
 
 @Injectable()
-export class LoginMiddleware implements NestMiddleware {
+export class BrowserLoginMiddleware implements NestMiddleware {
   constructor(
     private readonly authService: AuthService,
     private readonly logger: Logger) {}
@@ -15,7 +15,8 @@ export class LoginMiddleware implements NestMiddleware {
     const token =
       req.headers['authorization']?.split(': ').pop()?.split(' ').pop() ?? req.body['token'] ?? req.query['token']
     if (!token) {
-      res.status(400).end()
+      this.logger.warn(`No API token supplied`)
+      res.status(400).json({message: 'Auth token required'})
       return
     }
 
@@ -35,4 +36,55 @@ export class LoginMiddleware implements NestMiddleware {
     _.set(req, 'account', account)
     next()
   }
+}
+
+@Injectable()
+export class HmacLoginMiddleware implements NestMiddleware {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly logger: Logger) {}
+
+    async use(req: Request, res: Response, next: NextFunction): Promise<void> {
+      // Get the timestamp and signature from headers
+      const timestamp = req.headers['x-timestamp'] as string
+      const providedSignature = req.headers['x-signature'] as string
+      const accountId = req.headers['x-account-id'] as string
+
+      if (!timestamp || !providedSignature || !accountId) {
+        this.logger.warn(`Missing headers`)
+        res.status(400).end()
+
+        return
+      }
+
+      const forDate = new Date()
+      const signatureVerificationResult = await this.authService.isHmacSignatureValid(
+        req,
+        300,
+        accountId,
+        timestamp,
+        providedSignature,
+        forDate
+      )
+      
+      // Verify the request is not too old (e.g., 5 minutes)
+      if (signatureVerificationResult === HmacValidationResult.REQUEST_TOO_OLD) {
+        const now = Math.floor(forDate.getTime() / 1000)
+        this.logger.warn(`Request too old: ${Math.abs(now - parseInt(timestamp))}s`)
+        res.status(429).end()
+
+        return
+      }
+      
+      // see if at least one token matches the signature
+      if (signatureVerificationResult === HmacValidationResult.INVALID_SIGNATURE) {
+        this.logger.warn(`Invalid signature`)
+        res.status(403).end()
+
+        return
+      }
+
+      this.logger.log('Signature verified')
+      next()
+    }
 }

--- a/src/azure/auth.module.ts
+++ b/src/azure/auth.module.ts
@@ -1,0 +1,15 @@
+
+import { Module } from '@nestjs/common'
+import { AuthService } from '../shared/auth/auth.service';
+import { PersistenceModule } from '../shared/persistence/persistence.module'
+import { ConfigModule } from '../shared/config/config.module';
+import { EmailsModule } from '../shared/emails/emails.module';
+import { AzureAccountsModule } from './accounts.module';
+
+@Module({
+   imports: [AzureAccountsModule, ConfigModule, EmailsModule, PersistenceModule],
+   controllers: [],
+   providers: [AuthService],
+   exports: [AuthService],
+})
+export class AzureAuthModule {}

--- a/src/azure/azure-api.module.ts
+++ b/src/azure/azure-api.module.ts
@@ -7,9 +7,11 @@ import { ConfigModule } from '../shared/config/config.module'
 import { Inject, Module, OnApplicationShutdown } from '@nestjs/common'
 import { Logger, LoggerModule } from 'nestjs-pino'
 import { PersistenceModule } from '../shared/persistence/persistence.module'
+import { AzureAuthModule } from './auth.module'
 
 @Module({
   imports: [
+    AzureAuthModule,
     AzureAccountsModule,
     ConfigModule,
     AzureCommentsModule,

--- a/src/console/console.service.ts
+++ b/src/console/console.service.ts
@@ -120,7 +120,7 @@ export class CliService {
     const account = await this.accountService.findById(args.account)
     if (!account) throw new Error(`No account found for id ${args.account}`)
     await this.tokenService.create(account)
-    const token = await this.accountService.token(account)
+    const token = await this.accountService.lastToken(account)
     if (!token) {
       throw new Error('Token not created')
     }

--- a/src/shared/accounts/account.service.ts
+++ b/src/shared/accounts/account.service.ts
@@ -79,7 +79,7 @@ export class AccountService {
     return this.recordToAccount(accounts[0])
   }
 
-  async token(account: Account): Promise<Token | undefined> {
+  async lastToken(account: Account): Promise<Token | undefined> {
     const t = await findCurrentToken.run({ accountId: account.id }, this.client)
     if (t.length === 0) return
 

--- a/src/shared/accounts/accounts.queries.ts
+++ b/src/shared/accounts/accounts.queries.ts
@@ -1,36 +1,27 @@
 /** Types generated for queries found in "src/shared/accounts/accounts.sql" */
-import { PreparedQuery } from '@pgtyped/runtime'
+import { PreparedQuery } from '@pgtyped/runtime';
+
+export type DateOrString = Date | string;
 
 /** 'Signup' parameters type */
 export interface ISignupParams {
-  createdAt: Date | null | void
-  email: string | null | void
-  id: string | null | void
-  password: string | null | void
-  username: string | null | void
+  createdAt?: DateOrString | null | void;
+  email?: string | null | void;
+  id?: string | null | void;
+  password?: string | null | void;
+  username?: string | null | void;
 }
 
 /** 'Signup' return type */
-export type ISignupResult = void
+export type ISignupResult = void;
 
 /** 'Signup' query type */
 export interface ISignupQuery {
-  params: ISignupParams
-  result: ISignupResult
+  params: ISignupParams;
+  result: ISignupResult;
 }
 
-const signupIR: any = {
-  usedParamSet: { id: true, username: true, email: true, password: true, createdAt: true },
-  params: [
-    { name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 72, b: 74 }] },
-    { name: 'username', required: false, transform: { type: 'scalar' }, locs: [{ a: 77, b: 85 }] },
-    { name: 'email', required: false, transform: { type: 'scalar' }, locs: [{ a: 88, b: 93 }] },
-    { name: 'password', required: false, transform: { type: 'scalar' }, locs: [{ a: 103, b: 111 }] },
-    { name: 'createdAt', required: false, transform: { type: 'scalar' }, locs: [{ a: 131, b: 140 }] },
-  ],
-  statement:
-    "INSERT INTO accounts (id, username, email, password, created_at) VALUES(:id, :username, :email, digest(:password::text, 'sha256'), :createdAt)",
-}
+const signupIR: any = {"usedParamSet":{"id":true,"username":true,"email":true,"password":true,"createdAt":true},"params":[{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":72,"b":74}]},{"name":"username","required":false,"transform":{"type":"scalar"},"locs":[{"a":77,"b":85}]},{"name":"email","required":false,"transform":{"type":"scalar"},"locs":[{"a":88,"b":93}]},{"name":"password","required":false,"transform":{"type":"scalar"},"locs":[{"a":103,"b":111}]},{"name":"createdAt","required":false,"transform":{"type":"scalar"},"locs":[{"a":131,"b":140}]}],"statement":"INSERT INTO accounts (id, username, email, password, created_at) VALUES(:id, :username, :email, digest(:password::text, 'sha256'), :createdAt)"};
 
 /**
  * Query generated from SQL:
@@ -38,31 +29,25 @@ const signupIR: any = {
  * INSERT INTO accounts (id, username, email, password, created_at) VALUES(:id, :username, :email, digest(:password::text, 'sha256'), :createdAt)
  * ```
  */
-export const signup = new PreparedQuery<ISignupParams, ISignupResult>(signupIR)
+export const signup = new PreparedQuery<ISignupParams,ISignupResult>(signupIR);
+
 
 /** 'InitialAccountSettings' parameters type */
 export interface IInitialAccountSettingsParams {
-  accountId: string | null | void
-  id: string | null | void
+  accountId?: string | null | void;
+  id?: string | null | void;
 }
 
 /** 'InitialAccountSettings' return type */
-export type IInitialAccountSettingsResult = void
+export type IInitialAccountSettingsResult = void;
 
 /** 'InitialAccountSettings' query type */
 export interface IInitialAccountSettingsQuery {
-  params: IInitialAccountSettingsParams
-  result: IInitialAccountSettingsResult
+  params: IInitialAccountSettingsParams;
+  result: IInitialAccountSettingsResult;
 }
 
-const initialAccountSettingsIR: any = {
-  usedParamSet: { id: true, accountId: true },
-  params: [
-    { name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 52, b: 54 }] },
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 57, b: 66 }] },
-  ],
-  statement: 'INSERT INTO account_settings(id, account_id) VALUES(:id, :accountId)',
-}
+const initialAccountSettingsIR: any = {"usedParamSet":{"id":true,"accountId":true},"params":[{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":52,"b":54}]},{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":57,"b":66}]}],"statement":"INSERT INTO account_settings(id, account_id) VALUES(:id, :accountId)"};
 
 /**
  * Query generated from SQL:
@@ -70,33 +55,25 @@ const initialAccountSettingsIR: any = {
  * INSERT INTO account_settings(id, account_id) VALUES(:id, :accountId)
  * ```
  */
-export const initialAccountSettings = new PreparedQuery<IInitialAccountSettingsParams, IInitialAccountSettingsResult>(
-  initialAccountSettingsIR
-)
+export const initialAccountSettings = new PreparedQuery<IInitialAccountSettingsParams,IInitialAccountSettingsResult>(initialAccountSettingsIR);
+
 
 /** 'InitialAccountEmailSettings' parameters type */
 export interface IInitialAccountEmailSettingsParams {
-  accountId: string | null | void
-  id: string | null | void
+  accountId?: string | null | void;
+  id?: string | null | void;
 }
 
 /** 'InitialAccountEmailSettings' return type */
-export type IInitialAccountEmailSettingsResult = void
+export type IInitialAccountEmailSettingsResult = void;
 
 /** 'InitialAccountEmailSettings' query type */
 export interface IInitialAccountEmailSettingsQuery {
-  params: IInitialAccountEmailSettingsParams
-  result: IInitialAccountEmailSettingsResult
+  params: IInitialAccountEmailSettingsParams;
+  result: IInitialAccountEmailSettingsResult;
 }
 
-const initialAccountEmailSettingsIR: any = {
-  usedParamSet: { id: true, accountId: true },
-  params: [
-    { name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 58, b: 60 }] },
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 63, b: 72 }] },
-  ],
-  statement: 'INSERT INTO account_email_settings(id, account_id) VALUES(:id, :accountId)',
-}
+const initialAccountEmailSettingsIR: any = {"usedParamSet":{"id":true,"accountId":true},"params":[{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":58,"b":60}]},{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":63,"b":72}]}],"statement":"INSERT INTO account_email_settings(id, account_id) VALUES(:id, :accountId)"};
 
 /**
  * Query generated from SQL:
@@ -104,40 +81,31 @@ const initialAccountEmailSettingsIR: any = {
  * INSERT INTO account_email_settings(id, account_id) VALUES(:id, :accountId)
  * ```
  */
-export const initialAccountEmailSettings = new PreparedQuery<
-  IInitialAccountEmailSettingsParams,
-  IInitialAccountEmailSettingsResult
->(initialAccountEmailSettingsIR)
+export const initialAccountEmailSettings = new PreparedQuery<IInitialAccountEmailSettingsParams,IInitialAccountEmailSettingsResult>(initialAccountEmailSettingsIR);
+
 
 /** 'Login' parameters type */
 export interface ILoginParams {
-  password: string | null | void
-  username: string | null | void
+  password?: string | null | void;
+  username?: string | null | void;
 }
 
 /** 'Login' return type */
 export interface ILoginResult {
-  created_at: Date
-  email: string
-  id: string
-  password: Buffer
-  username: string
+  created_at: Date;
+  email: string;
+  id: string;
+  password: Buffer;
+  username: string;
 }
 
 /** 'Login' query type */
 export interface ILoginQuery {
-  params: ILoginParams
-  result: ILoginResult
+  params: ILoginParams;
+  result: ILoginResult;
 }
 
-const loginIR: any = {
-  usedParamSet: { username: true, password: true },
-  params: [
-    { name: 'username', required: false, transform: { type: 'scalar' }, locs: [{ a: 38, b: 46 }] },
-    { name: 'password', required: false, transform: { type: 'scalar' }, locs: [{ a: 68, b: 76 }] },
-  ],
-  statement: "SELECT * FROM accounts WHERE username=:username AND password=digest(:password::text, 'sha256')",
-}
+const loginIR: any = {"usedParamSet":{"username":true,"password":true},"params":[{"name":"username","required":false,"transform":{"type":"scalar"},"locs":[{"a":38,"b":46}]},{"name":"password","required":false,"transform":{"type":"scalar"},"locs":[{"a":68,"b":76}]}],"statement":"SELECT * FROM accounts WHERE username=:username AND password=digest(:password::text, 'sha256')"};
 
 /**
  * Query generated from SQL:
@@ -145,33 +113,30 @@ const loginIR: any = {
  * SELECT * FROM accounts WHERE username=:username AND password=digest(:password::text, 'sha256')
  * ```
  */
-export const login = new PreparedQuery<ILoginParams, ILoginResult>(loginIR)
+export const login = new PreparedQuery<ILoginParams,ILoginResult>(loginIR);
+
 
 /** 'FindById' parameters type */
 export interface IFindByIdParams {
-  id: string | null | void
+  id?: string | null | void;
 }
 
 /** 'FindById' return type */
 export interface IFindByIdResult {
-  created_at: Date
-  email: string
-  id: string
-  password: Buffer
-  username: string
+  created_at: Date;
+  email: string;
+  id: string;
+  password: Buffer;
+  username: string;
 }
 
 /** 'FindById' query type */
 export interface IFindByIdQuery {
-  params: IFindByIdParams
-  result: IFindByIdResult
+  params: IFindByIdParams;
+  result: IFindByIdResult;
 }
 
-const findByIdIR: any = {
-  usedParamSet: { id: true },
-  params: [{ name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 32, b: 34 }] }],
-  statement: 'SELECT * FROM accounts WHERE id=:id',
-}
+const findByIdIR: any = {"usedParamSet":{"id":true},"params":[{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":32,"b":34}]}],"statement":"SELECT * FROM accounts WHERE id=:id"};
 
 /**
  * Query generated from SQL:
@@ -179,33 +144,30 @@ const findByIdIR: any = {
  * SELECT * FROM accounts WHERE id=:id
  * ```
  */
-export const findById = new PreparedQuery<IFindByIdParams, IFindByIdResult>(findByIdIR)
+export const findById = new PreparedQuery<IFindByIdParams,IFindByIdResult>(findByIdIR);
+
 
 /** 'FindByUsername' parameters type */
 export interface IFindByUsernameParams {
-  username: string | null | void
+  username?: string | null | void;
 }
 
 /** 'FindByUsername' return type */
 export interface IFindByUsernameResult {
-  created_at: Date
-  email: string
-  id: string
-  password: Buffer
-  username: string
+  created_at: Date;
+  email: string;
+  id: string;
+  password: Buffer;
+  username: string;
 }
 
 /** 'FindByUsername' query type */
 export interface IFindByUsernameQuery {
-  params: IFindByUsernameParams
-  result: IFindByUsernameResult
+  params: IFindByUsernameParams;
+  result: IFindByUsernameResult;
 }
 
-const findByUsernameIR: any = {
-  usedParamSet: { username: true },
-  params: [{ name: 'username', required: false, transform: { type: 'scalar' }, locs: [{ a: 38, b: 46 }] }],
-  statement: 'SELECT * FROM accounts WHERE username=:username',
-}
+const findByUsernameIR: any = {"usedParamSet":{"username":true},"params":[{"name":"username","required":false,"transform":{"type":"scalar"},"locs":[{"a":38,"b":46}]}],"statement":"SELECT * FROM accounts WHERE username=:username"};
 
 /**
  * Query generated from SQL:
@@ -213,33 +175,30 @@ const findByUsernameIR: any = {
  * SELECT * FROM accounts WHERE username=:username
  * ```
  */
-export const findByUsername = new PreparedQuery<IFindByUsernameParams, IFindByUsernameResult>(findByUsernameIR)
+export const findByUsername = new PreparedQuery<IFindByUsernameParams,IFindByUsernameResult>(findByUsernameIR);
+
 
 /** 'FindByEmail' parameters type */
 export interface IFindByEmailParams {
-  email: string | null | void
+  email?: string | null | void;
 }
 
 /** 'FindByEmail' return type */
 export interface IFindByEmailResult {
-  created_at: Date
-  email: string
-  id: string
-  password: Buffer
-  username: string
+  created_at: Date;
+  email: string;
+  id: string;
+  password: Buffer;
+  username: string;
 }
 
 /** 'FindByEmail' query type */
 export interface IFindByEmailQuery {
-  params: IFindByEmailParams
-  result: IFindByEmailResult
+  params: IFindByEmailParams;
+  result: IFindByEmailResult;
 }
 
-const findByEmailIR: any = {
-  usedParamSet: { email: true },
-  params: [{ name: 'email', required: false, transform: { type: 'scalar' }, locs: [{ a: 35, b: 40 }] }],
-  statement: 'SELECT * FROM accounts WHERE email=:email',
-}
+const findByEmailIR: any = {"usedParamSet":{"email":true},"params":[{"name":"email","required":false,"transform":{"type":"scalar"},"locs":[{"a":35,"b":40}]}],"statement":"SELECT * FROM accounts WHERE email=:email"};
 
 /**
  * Query generated from SQL:
@@ -247,35 +206,27 @@ const findByEmailIR: any = {
  * SELECT * FROM accounts WHERE email=:email
  * ```
  */
-export const findByEmail = new PreparedQuery<IFindByEmailParams, IFindByEmailResult>(findByEmailIR)
+export const findByEmail = new PreparedQuery<IFindByEmailParams,IFindByEmailResult>(findByEmailIR);
+
 
 /** 'CreateToken' parameters type */
 export interface ICreateTokenParams {
-  accountId: string | null | void
-  createdAt: Date | null | void
-  id: string | null | void
-  token: string | null | void
+  accountId?: string | null | void;
+  createdAt?: DateOrString | null | void;
+  id?: string | null | void;
+  token?: string | null | void;
 }
 
 /** 'CreateToken' return type */
-export type ICreateTokenResult = void
+export type ICreateTokenResult = void;
 
 /** 'CreateToken' query type */
 export interface ICreateTokenQuery {
-  params: ICreateTokenParams
-  result: ICreateTokenResult
+  params: ICreateTokenParams;
+  result: ICreateTokenResult;
 }
 
-const createTokenIR: any = {
-  usedParamSet: { id: true, accountId: true, token: true, createdAt: true },
-  params: [
-    { name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 63, b: 65 }] },
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 68, b: 77 }] },
-    { name: 'token', required: false, transform: { type: 'scalar' }, locs: [{ a: 80, b: 85 }] },
-    { name: 'createdAt', required: false, transform: { type: 'scalar' }, locs: [{ a: 88, b: 97 }] },
-  ],
-  statement: 'INSERT INTO tokens (id, account_id, token, created_at) VALUES (:id, :accountId, :token, :createdAt)',
-}
+const createTokenIR: any = {"usedParamSet":{"id":true,"accountId":true,"token":true,"createdAt":true},"params":[{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":63,"b":65}]},{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":68,"b":77}]},{"name":"token","required":false,"transform":{"type":"scalar"},"locs":[{"a":80,"b":85}]},{"name":"createdAt","required":false,"transform":{"type":"scalar"},"locs":[{"a":88,"b":97}]}],"statement":"INSERT INTO tokens (id, account_id, token, created_at) VALUES (:id, :accountId, :token, :createdAt)"};
 
 /**
  * Query generated from SQL:
@@ -283,31 +234,25 @@ const createTokenIR: any = {
  * INSERT INTO tokens (id, account_id, token, created_at) VALUES (:id, :accountId, :token, :createdAt)
  * ```
  */
-export const createToken = new PreparedQuery<ICreateTokenParams, ICreateTokenResult>(createTokenIR)
+export const createToken = new PreparedQuery<ICreateTokenParams,ICreateTokenResult>(createTokenIR);
+
 
 /** 'RevokeToken' parameters type */
 export interface IRevokeTokenParams {
-  revokedAt: Date | null | void
-  token: string | null | void
+  revokedAt?: DateOrString | null | void;
+  token?: string | null | void;
 }
 
 /** 'RevokeToken' return type */
-export type IRevokeTokenResult = void
+export type IRevokeTokenResult = void;
 
 /** 'RevokeToken' query type */
 export interface IRevokeTokenQuery {
-  params: IRevokeTokenParams
-  result: IRevokeTokenResult
+  params: IRevokeTokenParams;
+  result: IRevokeTokenResult;
 }
 
-const revokeTokenIR: any = {
-  usedParamSet: { revokedAt: true, token: true },
-  params: [
-    { name: 'revokedAt', required: false, transform: { type: 'scalar' }, locs: [{ a: 29, b: 38 }] },
-    { name: 'token', required: false, transform: { type: 'scalar' }, locs: [{ a: 52, b: 57 }] },
-  ],
-  statement: 'UPDATE tokens SET revoked_at=:revokedAt WHERE token=:token',
-}
+const revokeTokenIR: any = {"usedParamSet":{"revokedAt":true,"token":true},"params":[{"name":"revokedAt","required":false,"transform":{"type":"scalar"},"locs":[{"a":29,"b":38}]},{"name":"token","required":false,"transform":{"type":"scalar"},"locs":[{"a":52,"b":57}]}],"statement":"UPDATE tokens SET revoked_at=:revokedAt WHERE token=:token"};
 
 /**
  * Query generated from SQL:
@@ -315,33 +260,30 @@ const revokeTokenIR: any = {
  * UPDATE tokens SET revoked_at=:revokedAt WHERE token=:token
  * ```
  */
-export const revokeToken = new PreparedQuery<IRevokeTokenParams, IRevokeTokenResult>(revokeTokenIR)
+export const revokeToken = new PreparedQuery<IRevokeTokenParams,IRevokeTokenResult>(revokeTokenIR);
+
 
 /** 'FindToken' parameters type */
 export interface IFindTokenParams {
-  token: string | null | void
+  token?: string | null | void;
 }
 
 /** 'FindToken' return type */
 export interface IFindTokenResult {
-  account_id: string
-  created_at: Date
-  id: string
-  revoked_at: Date | null
-  token: string
+  account_id: string;
+  created_at: Date;
+  id: string;
+  revoked_at: Date | null;
+  token: string;
 }
 
 /** 'FindToken' query type */
 export interface IFindTokenQuery {
-  params: IFindTokenParams
-  result: IFindTokenResult
+  params: IFindTokenParams;
+  result: IFindTokenResult;
 }
 
-const findTokenIR: any = {
-  usedParamSet: { token: true },
-  params: [{ name: 'token', required: false, transform: { type: 'scalar' }, locs: [{ a: 33, b: 38 }] }],
-  statement: 'SELECT * FROM tokens WHERE token=:token',
-}
+const findTokenIR: any = {"usedParamSet":{"token":true},"params":[{"name":"token","required":false,"transform":{"type":"scalar"},"locs":[{"a":33,"b":38}]}],"statement":"SELECT * FROM tokens WHERE token=:token"};
 
 /**
  * Query generated from SQL:
@@ -349,68 +291,93 @@ const findTokenIR: any = {
  * SELECT * FROM tokens WHERE token=:token
  * ```
  */
-export const findToken = new PreparedQuery<IFindTokenParams, IFindTokenResult>(findTokenIR)
+export const findToken = new PreparedQuery<IFindTokenParams,IFindTokenResult>(findTokenIR);
+
 
 /** 'FindCurrentToken' parameters type */
 export interface IFindCurrentTokenParams {
-  accountId: string | null | void
+  accountId?: string | null | void;
 }
 
 /** 'FindCurrentToken' return type */
 export interface IFindCurrentTokenResult {
-  account_id: string
-  created_at: Date
-  id: string
-  revoked_at: Date | null
-  token: string
+  account_id: string;
+  created_at: Date;
+  id: string;
+  revoked_at: Date | null;
+  token: string;
 }
 
 /** 'FindCurrentToken' query type */
 export interface IFindCurrentTokenQuery {
-  params: IFindCurrentTokenParams
-  result: IFindCurrentTokenResult
+  params: IFindCurrentTokenParams;
+  result: IFindCurrentTokenResult;
 }
 
-const findCurrentTokenIR: any = {
-  usedParamSet: { accountId: true },
-  params: [{ name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 38, b: 47 }] }],
-  statement: 'SELECT * FROM tokens WHERE account_id=:accountId AND revoked_at IS NULL',
-}
+const findCurrentTokenIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":38,"b":47}]}],"statement":"SELECT * FROM tokens WHERE account_id=:accountId AND revoked_at IS NULL ORDER BY created_at DESC"};
 
 /**
  * Query generated from SQL:
  * ```
- * SELECT * FROM tokens WHERE account_id=:accountId AND revoked_at IS NULL
+ * SELECT * FROM tokens WHERE account_id=:accountId AND revoked_at IS NULL ORDER BY created_at DESC
  * ```
  */
-export const findCurrentToken = new PreparedQuery<IFindCurrentTokenParams, IFindCurrentTokenResult>(findCurrentTokenIR)
+export const findCurrentToken = new PreparedQuery<IFindCurrentTokenParams,IFindCurrentTokenResult>(findCurrentTokenIR);
+
+
+/** 'FindAllValidTokens' parameters type */
+export interface IFindAllValidTokensParams {
+  accountId?: string | null | void;
+}
+
+/** 'FindAllValidTokens' return type */
+export interface IFindAllValidTokensResult {
+  account_id: string;
+  created_at: Date;
+  id: string;
+  revoked_at: Date | null;
+  token: string;
+}
+
+/** 'FindAllValidTokens' query type */
+export interface IFindAllValidTokensQuery {
+  params: IFindAllValidTokensParams;
+  result: IFindAllValidTokensResult;
+}
+
+const findAllValidTokensIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":38,"b":47}]}],"statement":"SELECT * FROM tokens WHERE account_id=:accountId AND revoked_at IS NULL ORDER BY created_at DESC"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT * FROM tokens WHERE account_id=:accountId AND revoked_at IS NULL ORDER BY created_at DESC
+ * ```
+ */
+export const findAllValidTokens = new PreparedQuery<IFindAllValidTokensParams,IFindAllValidTokensResult>(findAllValidTokensIR);
+
 
 /** 'AccountSettings' parameters type */
 export interface IAccountSettingsParams {
-  accountId: string | null | void
+  accountId?: string | null | void;
 }
 
 /** 'AccountSettings' return type */
 export interface IAccountSettingsResult {
-  account_id: string
-  akismet_key: string | null
-  blog_url: string | null
-  id: string
-  require_moderation: boolean
-  use_akismet: boolean | null
+  account_id: string;
+  akismet_key: string | null;
+  blog_url: string | null;
+  id: string;
+  require_moderation: boolean;
+  use_akismet: boolean | null;
 }
 
 /** 'AccountSettings' query type */
 export interface IAccountSettingsQuery {
-  params: IAccountSettingsParams
-  result: IAccountSettingsResult
+  params: IAccountSettingsParams;
+  result: IAccountSettingsResult;
 }
 
-const accountSettingsIR: any = {
-  usedParamSet: { accountId: true },
-  params: [{ name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 48, b: 57 }] }],
-  statement: 'SELECT * FROM account_settings WHERE account_id=:accountId',
-}
+const accountSettingsIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":48,"b":57}]}],"statement":"SELECT * FROM account_settings WHERE account_id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -418,32 +385,29 @@ const accountSettingsIR: any = {
  * SELECT * FROM account_settings WHERE account_id=:accountId
  * ```
  */
-export const accountSettings = new PreparedQuery<IAccountSettingsParams, IAccountSettingsResult>(accountSettingsIR)
+export const accountSettings = new PreparedQuery<IAccountSettingsParams,IAccountSettingsResult>(accountSettingsIR);
+
 
 /** 'AccountEmailSettings' parameters type */
 export interface IAccountEmailSettingsParams {
-  accountId: string | null | void
+  accountId?: string | null | void;
 }
 
 /** 'AccountEmailSettings' return type */
 export interface IAccountEmailSettingsResult {
-  account_id: string
-  id: string
-  notify_on_comments: boolean | null
-  send_comments_digest: boolean | null
+  account_id: string;
+  id: string;
+  notify_on_comments: boolean | null;
+  send_comments_digest: boolean | null;
 }
 
 /** 'AccountEmailSettings' query type */
 export interface IAccountEmailSettingsQuery {
-  params: IAccountEmailSettingsParams
-  result: IAccountEmailSettingsResult
+  params: IAccountEmailSettingsParams;
+  result: IAccountEmailSettingsResult;
 }
 
-const accountEmailSettingsIR: any = {
-  usedParamSet: { accountId: true },
-  params: [{ name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 54, b: 63 }] }],
-  statement: 'SELECT * FROM account_email_settings WHERE account_id=:accountId',
-}
+const accountEmailSettingsIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":54,"b":63}]}],"statement":"SELECT * FROM account_email_settings WHERE account_id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -451,40 +415,28 @@ const accountEmailSettingsIR: any = {
  * SELECT * FROM account_email_settings WHERE account_id=:accountId
  * ```
  */
-export const accountEmailSettings = new PreparedQuery<IAccountEmailSettingsParams, IAccountEmailSettingsResult>(
-  accountEmailSettingsIR
-)
+export const accountEmailSettings = new PreparedQuery<IAccountEmailSettingsParams,IAccountEmailSettingsResult>(accountEmailSettingsIR);
+
 
 /** 'UpdateSettings' parameters type */
 export interface IUpdateSettingsParams {
-  accountId: string | null | void
-  akismetKey: string | null | void
-  blogUrl: string | null | void
-  requireModeration: boolean | null | void
-  useAkismet: boolean | null | void
+  accountId?: string | null | void;
+  akismetKey?: string | null | void;
+  blogUrl?: string | null | void;
+  requireModeration?: boolean | null | void;
+  useAkismet?: boolean | null | void;
 }
 
 /** 'UpdateSettings' return type */
-export type IUpdateSettingsResult = void
+export type IUpdateSettingsResult = void;
 
 /** 'UpdateSettings' query type */
 export interface IUpdateSettingsQuery {
-  params: IUpdateSettingsParams
-  result: IUpdateSettingsResult
+  params: IUpdateSettingsParams;
+  result: IUpdateSettingsResult;
 }
 
-const updateSettingsIR: any = {
-  usedParamSet: { requireModeration: true, blogUrl: true, useAkismet: true, akismetKey: true, accountId: true },
-  params: [
-    { name: 'requireModeration', required: false, transform: { type: 'scalar' }, locs: [{ a: 47, b: 64 }] },
-    { name: 'blogUrl', required: false, transform: { type: 'scalar' }, locs: [{ a: 76, b: 83 }] },
-    { name: 'useAkismet', required: false, transform: { type: 'scalar' }, locs: [{ a: 98, b: 108 }] },
-    { name: 'akismetKey', required: false, transform: { type: 'scalar' }, locs: [{ a: 123, b: 133 }] },
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 152, b: 161 }] },
-  ],
-  statement:
-    'UPDATE account_settings SET require_moderation=:requireModeration, blog_url=:blogUrl, use_akismet=:useAkismet, akismet_key=:akismetKey WHERE account_id=:accountId',
-}
+const updateSettingsIR: any = {"usedParamSet":{"requireModeration":true,"blogUrl":true,"useAkismet":true,"akismetKey":true,"accountId":true},"params":[{"name":"requireModeration","required":false,"transform":{"type":"scalar"},"locs":[{"a":47,"b":64}]},{"name":"blogUrl","required":false,"transform":{"type":"scalar"},"locs":[{"a":76,"b":83}]},{"name":"useAkismet","required":false,"transform":{"type":"scalar"},"locs":[{"a":98,"b":108}]},{"name":"akismetKey","required":false,"transform":{"type":"scalar"},"locs":[{"a":123,"b":133}]},{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":152,"b":161}]}],"statement":"UPDATE account_settings SET require_moderation=:requireModeration, blog_url=:blogUrl, use_akismet=:useAkismet, akismet_key=:akismetKey WHERE account_id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -492,34 +444,26 @@ const updateSettingsIR: any = {
  * UPDATE account_settings SET require_moderation=:requireModeration, blog_url=:blogUrl, use_akismet=:useAkismet, akismet_key=:akismetKey WHERE account_id=:accountId
  * ```
  */
-export const updateSettings = new PreparedQuery<IUpdateSettingsParams, IUpdateSettingsResult>(updateSettingsIR)
+export const updateSettings = new PreparedQuery<IUpdateSettingsParams,IUpdateSettingsResult>(updateSettingsIR);
+
 
 /** 'UpdateEmailSettings' parameters type */
 export interface IUpdateEmailSettingsParams {
-  accountId: string | null | void
-  notifyOnComments: boolean | null | void
-  sendCommentsDigest: boolean | null | void
+  accountId?: string | null | void;
+  notifyOnComments?: boolean | null | void;
+  sendCommentsDigest?: boolean | null | void;
 }
 
 /** 'UpdateEmailSettings' return type */
-export type IUpdateEmailSettingsResult = void
+export type IUpdateEmailSettingsResult = void;
 
 /** 'UpdateEmailSettings' query type */
 export interface IUpdateEmailSettingsQuery {
-  params: IUpdateEmailSettingsParams
-  result: IUpdateEmailSettingsResult
+  params: IUpdateEmailSettingsParams;
+  result: IUpdateEmailSettingsResult;
 }
 
-const updateEmailSettingsIR: any = {
-  usedParamSet: { notifyOnComments: true, sendCommentsDigest: true, accountId: true },
-  params: [
-    { name: 'notifyOnComments', required: false, transform: { type: 'scalar' }, locs: [{ a: 53, b: 69 }] },
-    { name: 'sendCommentsDigest', required: false, transform: { type: 'scalar' }, locs: [{ a: 93, b: 111 }] },
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 130, b: 139 }] },
-  ],
-  statement:
-    'UPDATE account_email_settings SET notify_on_comments=:notifyOnComments, send_comments_digest=:sendCommentsDigest WHERE account_id=:accountId',
-}
+const updateEmailSettingsIR: any = {"usedParamSet":{"notifyOnComments":true,"sendCommentsDigest":true,"accountId":true},"params":[{"name":"notifyOnComments","required":false,"transform":{"type":"scalar"},"locs":[{"a":53,"b":69}]},{"name":"sendCommentsDigest","required":false,"transform":{"type":"scalar"},"locs":[{"a":93,"b":111}]},{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":130,"b":139}]}],"statement":"UPDATE account_email_settings SET notify_on_comments=:notifyOnComments, send_comments_digest=:sendCommentsDigest WHERE account_id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -527,39 +471,31 @@ const updateEmailSettingsIR: any = {
  * UPDATE account_email_settings SET notify_on_comments=:notifyOnComments, send_comments_digest=:sendCommentsDigest WHERE account_id=:accountId
  * ```
  */
-export const updateEmailSettings = new PreparedQuery<IUpdateEmailSettingsParams, IUpdateEmailSettingsResult>(
-  updateEmailSettingsIR
-)
+export const updateEmailSettings = new PreparedQuery<IUpdateEmailSettingsParams,IUpdateEmailSettingsResult>(updateEmailSettingsIR);
+
 
 /** 'FindUserByEmailOrUsername' parameters type */
 export interface IFindUserByEmailOrUsernameParams {
-  email: string | null | void
-  username: string | null | void
+  email?: string | null | void;
+  username?: string | null | void;
 }
 
 /** 'FindUserByEmailOrUsername' return type */
 export interface IFindUserByEmailOrUsernameResult {
-  created_at: Date
-  email: string
-  id: string
-  password: Buffer
-  username: string
+  created_at: Date;
+  email: string;
+  id: string;
+  password: Buffer;
+  username: string;
 }
 
 /** 'FindUserByEmailOrUsername' query type */
 export interface IFindUserByEmailOrUsernameQuery {
-  params: IFindUserByEmailOrUsernameParams
-  result: IFindUserByEmailOrUsernameResult
+  params: IFindUserByEmailOrUsernameParams;
+  result: IFindUserByEmailOrUsernameResult;
 }
 
-const findUserByEmailOrUsernameIR: any = {
-  usedParamSet: { username: true, email: true },
-  params: [
-    { name: 'username', required: false, transform: { type: 'scalar' }, locs: [{ a: 38, b: 46 }] },
-    { name: 'email', required: false, transform: { type: 'scalar' }, locs: [{ a: 57, b: 62 }] },
-  ],
-  statement: 'SELECT * FROM accounts WHERE username=:username OR email=:email',
-}
+const findUserByEmailOrUsernameIR: any = {"usedParamSet":{"username":true,"email":true},"params":[{"name":"username","required":false,"transform":{"type":"scalar"},"locs":[{"a":38,"b":46}]},{"name":"email","required":false,"transform":{"type":"scalar"},"locs":[{"a":57,"b":62}]}],"statement":"SELECT * FROM accounts WHERE username=:username OR email=:email"};
 
 /**
  * Query generated from SQL:
@@ -567,34 +503,25 @@ const findUserByEmailOrUsernameIR: any = {
  * SELECT * FROM accounts WHERE username=:username OR email=:email
  * ```
  */
-export const findUserByEmailOrUsername = new PreparedQuery<
-  IFindUserByEmailOrUsernameParams,
-  IFindUserByEmailOrUsernameResult
->(findUserByEmailOrUsernameIR)
+export const findUserByEmailOrUsername = new PreparedQuery<IFindUserByEmailOrUsernameParams,IFindUserByEmailOrUsernameResult>(findUserByEmailOrUsernameIR);
+
 
 /** 'ChangeAccountEmail' parameters type */
 export interface IChangeAccountEmailParams {
-  accountId: string | null | void
-  email: string | null | void
+  accountId?: string | null | void;
+  email?: string | null | void;
 }
 
 /** 'ChangeAccountEmail' return type */
-export type IChangeAccountEmailResult = void
+export type IChangeAccountEmailResult = void;
 
 /** 'ChangeAccountEmail' query type */
 export interface IChangeAccountEmailQuery {
-  params: IChangeAccountEmailParams
-  result: IChangeAccountEmailResult
+  params: IChangeAccountEmailParams;
+  result: IChangeAccountEmailResult;
 }
 
-const changeAccountEmailIR: any = {
-  usedParamSet: { email: true, accountId: true },
-  params: [
-    { name: 'email', required: false, transform: { type: 'scalar' }, locs: [{ a: 26, b: 31 }] },
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 42, b: 51 }] },
-  ],
-  statement: 'UPDATE accounts SET email=:email WHERE id=:accountId',
-}
+const changeAccountEmailIR: any = {"usedParamSet":{"email":true,"accountId":true},"params":[{"name":"email","required":false,"transform":{"type":"scalar"},"locs":[{"a":26,"b":31}]},{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":42,"b":51}]}],"statement":"UPDATE accounts SET email=:email WHERE id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -602,29 +529,24 @@ const changeAccountEmailIR: any = {
  * UPDATE accounts SET email=:email WHERE id=:accountId
  * ```
  */
-export const changeAccountEmail = new PreparedQuery<IChangeAccountEmailParams, IChangeAccountEmailResult>(
-  changeAccountEmailIR
-)
+export const changeAccountEmail = new PreparedQuery<IChangeAccountEmailParams,IChangeAccountEmailResult>(changeAccountEmailIR);
+
 
 /** 'DeleteSettings' parameters type */
 export interface IDeleteSettingsParams {
-  accountId: string | null | void
+  accountId?: string | null | void;
 }
 
 /** 'DeleteSettings' return type */
-export type IDeleteSettingsResult = void
+export type IDeleteSettingsResult = void;
 
 /** 'DeleteSettings' query type */
 export interface IDeleteSettingsQuery {
-  params: IDeleteSettingsParams
-  result: IDeleteSettingsResult
+  params: IDeleteSettingsParams;
+  result: IDeleteSettingsResult;
 }
 
-const deleteSettingsIR: any = {
-  usedParamSet: { accountId: true },
-  params: [{ name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 46, b: 55 }] }],
-  statement: 'DELETE FROM account_settings WHERE account_id=:accountId',
-}
+const deleteSettingsIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":46,"b":55}]}],"statement":"DELETE FROM account_settings WHERE account_id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -632,27 +554,24 @@ const deleteSettingsIR: any = {
  * DELETE FROM account_settings WHERE account_id=:accountId
  * ```
  */
-export const deleteSettings = new PreparedQuery<IDeleteSettingsParams, IDeleteSettingsResult>(deleteSettingsIR)
+export const deleteSettings = new PreparedQuery<IDeleteSettingsParams,IDeleteSettingsResult>(deleteSettingsIR);
+
 
 /** 'DeleteEmailSettings' parameters type */
 export interface IDeleteEmailSettingsParams {
-  accountId: string | null | void
+  accountId?: string | null | void;
 }
 
 /** 'DeleteEmailSettings' return type */
-export type IDeleteEmailSettingsResult = void
+export type IDeleteEmailSettingsResult = void;
 
 /** 'DeleteEmailSettings' query type */
 export interface IDeleteEmailSettingsQuery {
-  params: IDeleteEmailSettingsParams
-  result: IDeleteEmailSettingsResult
+  params: IDeleteEmailSettingsParams;
+  result: IDeleteEmailSettingsResult;
 }
 
-const deleteEmailSettingsIR: any = {
-  usedParamSet: { accountId: true },
-  params: [{ name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 52, b: 61 }] }],
-  statement: 'DELETE FROM account_email_settings WHERE account_id=:accountId',
-}
+const deleteEmailSettingsIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":52,"b":61}]}],"statement":"DELETE FROM account_email_settings WHERE account_id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -660,29 +579,24 @@ const deleteEmailSettingsIR: any = {
  * DELETE FROM account_email_settings WHERE account_id=:accountId
  * ```
  */
-export const deleteEmailSettings = new PreparedQuery<IDeleteEmailSettingsParams, IDeleteEmailSettingsResult>(
-  deleteEmailSettingsIR
-)
+export const deleteEmailSettings = new PreparedQuery<IDeleteEmailSettingsParams,IDeleteEmailSettingsResult>(deleteEmailSettingsIR);
+
 
 /** 'DeleteTokens' parameters type */
 export interface IDeleteTokensParams {
-  accountId: string | null | void
+  accountId?: string | null | void;
 }
 
 /** 'DeleteTokens' return type */
-export type IDeleteTokensResult = void
+export type IDeleteTokensResult = void;
 
 /** 'DeleteTokens' query type */
 export interface IDeleteTokensQuery {
-  params: IDeleteTokensParams
-  result: IDeleteTokensResult
+  params: IDeleteTokensParams;
+  result: IDeleteTokensResult;
 }
 
-const deleteTokensIR: any = {
-  usedParamSet: { accountId: true },
-  params: [{ name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 36, b: 45 }] }],
-  statement: 'DELETE FROM tokens WHERE account_id=:accountId',
-}
+const deleteTokensIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":36,"b":45}]}],"statement":"DELETE FROM tokens WHERE account_id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -690,27 +604,24 @@ const deleteTokensIR: any = {
  * DELETE FROM tokens WHERE account_id=:accountId
  * ```
  */
-export const deleteTokens = new PreparedQuery<IDeleteTokensParams, IDeleteTokensResult>(deleteTokensIR)
+export const deleteTokens = new PreparedQuery<IDeleteTokensParams,IDeleteTokensResult>(deleteTokensIR);
+
 
 /** 'CloseAccount' parameters type */
 export interface ICloseAccountParams {
-  accountId: string | null | void
+  accountId?: string | null | void;
 }
 
 /** 'CloseAccount' return type */
-export type ICloseAccountResult = void
+export type ICloseAccountResult = void;
 
 /** 'CloseAccount' query type */
 export interface ICloseAccountQuery {
-  params: ICloseAccountParams
-  result: ICloseAccountResult
+  params: ICloseAccountParams;
+  result: ICloseAccountResult;
 }
 
-const closeAccountIR: any = {
-  usedParamSet: { accountId: true },
-  params: [{ name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 30, b: 39 }] }],
-  statement: 'DELETE FROM accounts WHERE id=:accountId',
-}
+const closeAccountIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":30,"b":39}]}],"statement":"DELETE FROM accounts WHERE id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -718,4 +629,6 @@ const closeAccountIR: any = {
  * DELETE FROM accounts WHERE id=:accountId
  * ```
  */
-export const closeAccount = new PreparedQuery<ICloseAccountParams, ICloseAccountResult>(closeAccountIR)
+export const closeAccount = new PreparedQuery<ICloseAccountParams,ICloseAccountResult>(closeAccountIR);
+
+

--- a/src/shared/accounts/accounts.sql
+++ b/src/shared/accounts/accounts.sql
@@ -29,7 +29,10 @@ UPDATE tokens SET revoked_at=:revokedAt WHERE token=:token;
 SELECT * FROM tokens WHERE token=:token;
 
 /* @name findCurrentToken */
-SELECT * FROM tokens WHERE account_id=:accountId AND revoked_at IS NULL;
+SELECT * FROM tokens WHERE account_id=:accountId AND revoked_at IS NULL ORDER BY created_at DESC;
+
+/* @name findAllValidTokens */
+SELECT * FROM tokens WHERE account_id=:accountId AND revoked_at IS NULL ORDER BY created_at DESC;
 
 /* @name accountSettings */
 SELECT * FROM account_settings WHERE account_id=:accountId;

--- a/src/shared/auth/auth.queries.ts
+++ b/src/shared/auth/auth.queries.ts
@@ -1,29 +1,24 @@
 /** Types generated for queries found in "src/shared/auth/auth.sql" */
-import { PreparedQuery } from '@pgtyped/runtime'
+import { PreparedQuery } from '@pgtyped/runtime';
+
+export type DateOrString = Date | string;
 
 /** 'ExpirePendingTokens' parameters type */
 export interface IExpirePendingTokensParams {
-  accountId: string | null | void
-  now: Date | null | void
+  accountId?: string | null | void;
+  now?: DateOrString | null | void;
 }
 
 /** 'ExpirePendingTokens' return type */
-export type IExpirePendingTokensResult = void
+export type IExpirePendingTokensResult = void;
 
 /** 'ExpirePendingTokens' query type */
 export interface IExpirePendingTokensQuery {
-  params: IExpirePendingTokensParams
-  result: IExpirePendingTokensResult
+  params: IExpirePendingTokensParams;
+  result: IExpirePendingTokensResult;
 }
 
-const expirePendingTokensIR: any = {
-  usedParamSet: { now: true, accountId: true },
-  params: [
-    { name: 'now', required: false, transform: { type: 'scalar' }, locs: [{ a: 35, b: 38 }] },
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 57, b: 66 }] },
-  ],
-  statement: 'UPDATE password_resets SET used_at=:now WHERE account_id=:accountId AND used_at IS NULL',
-}
+const expirePendingTokensIR: any = {"usedParamSet":{"now":true,"accountId":true},"params":[{"name":"now","required":false,"transform":{"type":"scalar"},"locs":[{"a":35,"b":38}]},{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":57,"b":66}]}],"statement":"UPDATE password_resets SET used_at=:now WHERE account_id=:accountId AND used_at IS NULL"};
 
 /**
  * Query generated from SQL:
@@ -31,40 +26,28 @@ const expirePendingTokensIR: any = {
  * UPDATE password_resets SET used_at=:now WHERE account_id=:accountId AND used_at IS NULL
  * ```
  */
-export const expirePendingTokens = new PreparedQuery<IExpirePendingTokensParams, IExpirePendingTokensResult>(
-  expirePendingTokensIR
-)
+export const expirePendingTokens = new PreparedQuery<IExpirePendingTokensParams,IExpirePendingTokensResult>(expirePendingTokensIR);
+
 
 /** 'CreatePasswordResetToken' parameters type */
 export interface ICreatePasswordResetTokenParams {
-  accountId: string | null | void
-  createdAt: Date | null | void
-  expiresAt: Date | null | void
-  id: string | null | void
-  token: string | null | void
+  accountId?: string | null | void;
+  createdAt?: DateOrString | null | void;
+  expiresAt?: DateOrString | null | void;
+  id?: string | null | void;
+  token?: string | null | void;
 }
 
 /** 'CreatePasswordResetToken' return type */
-export type ICreatePasswordResetTokenResult = void
+export type ICreatePasswordResetTokenResult = void;
 
 /** 'CreatePasswordResetToken' query type */
 export interface ICreatePasswordResetTokenQuery {
-  params: ICreatePasswordResetTokenParams
-  result: ICreatePasswordResetTokenResult
+  params: ICreatePasswordResetTokenParams;
+  result: ICreatePasswordResetTokenResult;
 }
 
-const createPasswordResetTokenIR: any = {
-  usedParamSet: { id: true, accountId: true, token: true, createdAt: true, expiresAt: true },
-  params: [
-    { name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 84, b: 86 }] },
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 89, b: 98 }] },
-    { name: 'token', required: false, transform: { type: 'scalar' }, locs: [{ a: 101, b: 106 }] },
-    { name: 'createdAt', required: false, transform: { type: 'scalar' }, locs: [{ a: 109, b: 118 }] },
-    { name: 'expiresAt', required: false, transform: { type: 'scalar' }, locs: [{ a: 121, b: 130 }] },
-  ],
-  statement:
-    'INSERT INTO password_resets (id, account_id, token, created_at, expires_at) VALUES (:id, :accountId, :token, :createdAt, :expiresAt)',
-}
+const createPasswordResetTokenIR: any = {"usedParamSet":{"id":true,"accountId":true,"token":true,"createdAt":true,"expiresAt":true},"params":[{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":84,"b":86}]},{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":89,"b":98}]},{"name":"token","required":false,"transform":{"type":"scalar"},"locs":[{"a":101,"b":106}]},{"name":"createdAt","required":false,"transform":{"type":"scalar"},"locs":[{"a":109,"b":118}]},{"name":"expiresAt","required":false,"transform":{"type":"scalar"},"locs":[{"a":121,"b":130}]}],"statement":"INSERT INTO password_resets (id, account_id, token, created_at, expires_at) VALUES (:id, :accountId, :token, :createdAt, :expiresAt)"};
 
 /**
  * Query generated from SQL:
@@ -72,41 +55,32 @@ const createPasswordResetTokenIR: any = {
  * INSERT INTO password_resets (id, account_id, token, created_at, expires_at) VALUES (:id, :accountId, :token, :createdAt, :expiresAt)
  * ```
  */
-export const createPasswordResetToken = new PreparedQuery<
-  ICreatePasswordResetTokenParams,
-  ICreatePasswordResetTokenResult
->(createPasswordResetTokenIR)
+export const createPasswordResetToken = new PreparedQuery<ICreatePasswordResetTokenParams,ICreatePasswordResetTokenResult>(createPasswordResetTokenIR);
+
 
 /** 'IsTokenUsable' parameters type */
 export interface IIsTokenUsableParams {
-  date: Date | null | void
-  token: string | null | void
+  date?: DateOrString | null | void;
+  token?: string | null | void;
 }
 
 /** 'IsTokenUsable' return type */
 export interface IIsTokenUsableResult {
-  account_id: string
-  created_at: Date
-  expires_at: Date
-  id: string
-  token: string
-  used_at: Date | null
+  account_id: string;
+  created_at: Date;
+  expires_at: Date;
+  id: string;
+  token: string;
+  used_at: Date | null;
 }
 
 /** 'IsTokenUsable' query type */
 export interface IIsTokenUsableQuery {
-  params: IIsTokenUsableParams
-  result: IIsTokenUsableResult
+  params: IIsTokenUsableParams;
+  result: IIsTokenUsableResult;
 }
 
-const isTokenUsableIR: any = {
-  usedParamSet: { token: true, date: true },
-  params: [
-    { name: 'token', required: false, transform: { type: 'scalar' }, locs: [{ a: 42, b: 47 }] },
-    { name: 'date', required: false, transform: { type: 'scalar' }, locs: [{ a: 86, b: 90 }] },
-  ],
-  statement: 'SELECT * FROM password_resets WHERE token=:token AND used_at IS NULL AND expires_at > :date',
-}
+const isTokenUsableIR: any = {"usedParamSet":{"token":true,"date":true},"params":[{"name":"token","required":false,"transform":{"type":"scalar"},"locs":[{"a":42,"b":47}]},{"name":"date","required":false,"transform":{"type":"scalar"},"locs":[{"a":86,"b":90}]}],"statement":"SELECT * FROM password_resets WHERE token=:token AND used_at IS NULL AND expires_at > :date"};
 
 /**
  * Query generated from SQL:
@@ -114,33 +88,30 @@ const isTokenUsableIR: any = {
  * SELECT * FROM password_resets WHERE token=:token AND used_at IS NULL AND expires_at > :date
  * ```
  */
-export const isTokenUsable = new PreparedQuery<IIsTokenUsableParams, IIsTokenUsableResult>(isTokenUsableIR)
+export const isTokenUsable = new PreparedQuery<IIsTokenUsableParams,IIsTokenUsableResult>(isTokenUsableIR);
+
 
 /** 'AccountFromToken' parameters type */
 export interface IAccountFromTokenParams {
-  token: string | null | void
+  token?: string | null | void;
 }
 
 /** 'AccountFromToken' return type */
 export interface IAccountFromTokenResult {
-  created_at: Date
-  email: string
-  id: string
-  password: Buffer
-  username: string
+  created_at: Date;
+  email: string;
+  id: string;
+  password: Buffer;
+  username: string;
 }
 
 /** 'AccountFromToken' query type */
 export interface IAccountFromTokenQuery {
-  params: IAccountFromTokenParams
-  result: IAccountFromTokenResult
+  params: IAccountFromTokenParams;
+  result: IAccountFromTokenResult;
 }
 
-const accountFromTokenIR: any = {
-  usedParamSet: { token: true },
-  params: [{ name: 'token', required: false, transform: { type: 'scalar' }, locs: [{ a: 87, b: 92 }] }],
-  statement: 'SELECT a.* FROM accounts a JOIN password_resets p ON (a.id=p.account_id) WHERE p.token=:token',
-}
+const accountFromTokenIR: any = {"usedParamSet":{"token":true},"params":[{"name":"token","required":false,"transform":{"type":"scalar"},"locs":[{"a":87,"b":92}]}],"statement":"SELECT a.* FROM accounts a JOIN password_resets p ON (a.id=p.account_id) WHERE p.token=:token"};
 
 /**
  * Query generated from SQL:
@@ -148,31 +119,25 @@ const accountFromTokenIR: any = {
  * SELECT a.* FROM accounts a JOIN password_resets p ON (a.id=p.account_id) WHERE p.token=:token
  * ```
  */
-export const accountFromToken = new PreparedQuery<IAccountFromTokenParams, IAccountFromTokenResult>(accountFromTokenIR)
+export const accountFromToken = new PreparedQuery<IAccountFromTokenParams,IAccountFromTokenResult>(accountFromTokenIR);
+
 
 /** 'ChangePassword' parameters type */
 export interface IChangePasswordParams {
-  accountId: string | null | void
-  password: string | null | void
+  accountId?: string | null | void;
+  password?: string | null | void;
 }
 
 /** 'ChangePassword' return type */
-export type IChangePasswordResult = void
+export type IChangePasswordResult = void;
 
 /** 'ChangePassword' query type */
 export interface IChangePasswordQuery {
-  params: IChangePasswordParams
-  result: IChangePasswordResult
+  params: IChangePasswordParams;
+  result: IChangePasswordResult;
 }
 
-const changePasswordIR: any = {
-  usedParamSet: { password: true, accountId: true },
-  params: [
-    { name: 'password', required: false, transform: { type: 'scalar' }, locs: [{ a: 36, b: 44 }] },
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 72, b: 81 }] },
-  ],
-  statement: "UPDATE accounts SET password=digest(:password::text, 'sha256') WHERE id=:accountId",
-}
+const changePasswordIR: any = {"usedParamSet":{"password":true,"accountId":true},"params":[{"name":"password","required":false,"transform":{"type":"scalar"},"locs":[{"a":36,"b":44}]},{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":72,"b":81}]}],"statement":"UPDATE accounts SET password=digest(:password::text, 'sha256') WHERE id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -180,4 +145,6 @@ const changePasswordIR: any = {
  * UPDATE accounts SET password=digest(:password::text, 'sha256') WHERE id=:accountId
  * ```
  */
-export const changePassword = new PreparedQuery<IChangePasswordParams, IChangePasswordResult>(changePasswordIR)
+export const changePassword = new PreparedQuery<IChangePasswordParams,IChangePasswordResult>(changePasswordIR);
+
+

--- a/src/shared/auth/auth.service.ts
+++ b/src/shared/auth/auth.service.ts
@@ -14,11 +14,9 @@ import { EmailService } from '../emails/email.service'
 import { Inject, Injectable } from '@nestjs/common'
 import { loginFromToken } from '../../api/api.queries'
 import moment from 'moment'
-import { Request } from 'express'
 import { SendMailService } from '../infra/sendmail.service'
 import { v4 as uuidv4 } from 'uuid'
 import { findAllValidTokens } from '../accounts/accounts.queries'
-import { HttpRequest } from '@azure/functions'
 
 @Injectable()
 export class AuthService {
@@ -107,7 +105,8 @@ export class AuthService {
   }
 
   async isHmacSignatureValid(
-      req: Request | HttpRequest,
+      httpMethod: string,
+      urlPath: string,
       expiryInSeconds: number,
       accountId: string,
       timestamp: string,
@@ -123,7 +122,7 @@ export class AuthService {
 
     const tryValidate = (token: string): boolean => {
       // Reconstruct the string to verify
-      const stringToSign = `${req.method}\n${req.url}\n${timestamp}`
+      const stringToSign = `${httpMethod}\n${urlPath}\n${timestamp}`
       
       // Create HMAC signature
       const hmac = crypto.createHmac('sha256', token)
@@ -141,7 +140,7 @@ export class AuthService {
 }
 
 export enum HmacValidationResult {
-  OK,
-  INVALID_SIGNATURE,
-  REQUEST_TOO_OLD,
+  OK = 'OK',
+  INVALID_SIGNATURE = 'KO',
+  REQUEST_TOO_OLD = 'OLD',
 }

--- a/src/shared/comments/comment.event.ts
+++ b/src/shared/comments/comment.event.ts
@@ -1,9 +1,9 @@
 import { Account } from '../accounts/account.interface'
-import { CommentDto } from './comment.interface'
+import { Comment } from './comment.interface'
 
 export interface CommentEventBody {
   account: Account
-  comment: CommentDto // TODO this should not be the DTO
+  comment: Comment
 }
 
 export class CommentEvent {

--- a/src/shared/comments/comment.service.ts
+++ b/src/shared/comments/comment.service.ts
@@ -43,19 +43,21 @@ export class CommentService {
     private readonly logger: Logger
   ) {}
 
-  async create(account: Account, comment: CommentBase, ip: string): Promise<CommentCreatedResult> {
+  async create(account: Account, comment: CommentBase, ip: string): Promise<CommentCreatedResult|string> {
     const settings = await this.accountService.settingsFor(account)
     const toModeration = settings?.requireModeration ?? false
+    const payload = this.commentToDbParam(account, comment)
     if (toModeration || (settings?.akismetKey && settings.useAkismet)) {
       const flagIt = toModeration || (settings && (await this.akismetService.isCommentSpam(settings, comment, ip)))
       if (flagIt) {
         this.logger.warn(`${toModeration ? 'Moderation enforced' : 'SPAM detected'}: ${JSON.stringify(comment)}`)
-        await flagCommentForUrl.run(this.commentToDbParam(account, comment), this.client)
+        await flagCommentForUrl.run(payload, this.client)
         return CommentCreatedResult.Flagged
       }
     }
-    await postCommentForUrl.run(this.commentToDbParam(account, comment), this.client)
-    return CommentCreatedResult.Created
+    await postCommentForUrl.run(payload, this.client)
+
+    return payload.id
   }
 
   async createWithOption(account: Account, comment: CommentBase, toModeration: boolean): Promise<CommentCreatedResult> {

--- a/src/shared/comments/comment.service.ts
+++ b/src/shared/comments/comment.service.ts
@@ -165,6 +165,10 @@ export class CommentService {
     )
   }
 
+  async deleteSingleById(commentId: string): Promise<void> {
+    await deleteSingleComment.run({ id: commentId }, this.client)
+  }
+
   async deleteSingle(comment: Comment): Promise<void> {
     await deleteSingleComment.run({ id: comment.id }, this.client)
   }

--- a/src/shared/comments/comments.module.ts
+++ b/src/shared/comments/comments.module.ts
@@ -4,8 +4,8 @@ import { CommentService } from './comment.service'
 import { ConfigModule } from '../config/config.module'
 import { ContentFilteringService } from './content-filtering-service'
 import { EmailsModule } from '../emails/emails.module'
-import { forwardRef, MiddlewareConsumer, Module, NestModule } from '@nestjs/common'
-import { LoginMiddleware } from '../../api/login.middleware'
+import { forwardRef, MiddlewareConsumer, Module, NestModule, RequestMethod } from '@nestjs/common'
+import { BrowserLoginMiddleware, HmacLoginMiddleware } from '../../api/login.middleware'
 import { PersistenceModule } from '../persistence/persistence.module'
 import { PgBossQueueModule } from '../queue/pgboss/pg-boss-queue.module'
 
@@ -17,6 +17,11 @@ import { PgBossQueueModule } from '../queue/pgboss/pg-boss-queue.module'
 })
 export class CommentsModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {
-    consumer.apply(LoginMiddleware).forRoutes('comments')
+    consumer.apply(BrowserLoginMiddleware)
+      .exclude({ path: 'comments/:commentId', method: RequestMethod.DELETE})
+      .forRoutes('comments')
+    
+    consumer.apply(HmacLoginMiddleware)
+      .forRoutes({ path: 'comments/:commentId', method: RequestMethod.DELETE})
   }
 }

--- a/src/shared/comments/comments.queries.ts
+++ b/src/shared/comments/comments.queries.ts
@@ -1,51 +1,32 @@
 /** Types generated for queries found in "src/shared/comments/comments.sql" */
-import { PreparedQuery } from '@pgtyped/runtime'
+import { PreparedQuery } from '@pgtyped/runtime';
+
+export type DateOrString = Date | string;
+
+export type NumberOrString = number | string;
 
 /** 'PostCommentForUrl' parameters type */
 export interface IPostCommentForUrlParams {
-  accountId: string | null | void
-  email: string | null | void
-  id: string | null | void
-  name: string | null | void
-  pageTitle: string | null | void
-  text: string | null | void
-  url: string | null | void
-  website: string | null | void
+  accountId?: string | null | void;
+  email?: string | null | void;
+  id?: string | null | void;
+  name?: string | null | void;
+  pageTitle?: string | null | void;
+  text?: string | null | void;
+  url?: string | null | void;
+  website?: string | null | void;
 }
 
 /** 'PostCommentForUrl' return type */
-export type IPostCommentForUrlResult = void
+export type IPostCommentForUrlResult = void;
 
 /** 'PostCommentForUrl' query type */
 export interface IPostCommentForUrlQuery {
-  params: IPostCommentForUrlParams
-  result: IPostCommentForUrlResult
+  params: IPostCommentForUrlParams;
+  result: IPostCommentForUrlResult;
 }
 
-const postCommentForUrlIR: any = {
-  usedParamSet: {
-    id: true,
-    accountId: true,
-    url: true,
-    pageTitle: true,
-    text: true,
-    name: true,
-    email: true,
-    website: true,
-  },
-  params: [
-    { name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 130, b: 132 }] },
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 135, b: 144 }] },
-    { name: 'url', required: false, transform: { type: 'scalar' }, locs: [{ a: 147, b: 150 }] },
-    { name: 'pageTitle', required: false, transform: { type: 'scalar' }, locs: [{ a: 153, b: 162 }] },
-    { name: 'text', required: false, transform: { type: 'scalar' }, locs: [{ a: 165, b: 169 }] },
-    { name: 'name', required: false, transform: { type: 'scalar' }, locs: [{ a: 172, b: 176 }] },
-    { name: 'email', required: false, transform: { type: 'scalar' }, locs: [{ a: 179, b: 184 }] },
-    { name: 'website', required: false, transform: { type: 'scalar' }, locs: [{ a: 187, b: 194 }] },
-  ],
-  statement:
-    "INSERT INTO comments(id, account_id, page_url, page_title, comment, reader_name, reader_email, reader_website, created_at) VALUES(:id, :accountId, :url, :pageTitle, :text, :name, :email, :website, 'now'::timestamp)",
-}
+const postCommentForUrlIR: any = {"usedParamSet":{"id":true,"accountId":true,"url":true,"pageTitle":true,"text":true,"name":true,"email":true,"website":true},"params":[{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":130,"b":132}]},{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":135,"b":144}]},{"name":"url","required":false,"transform":{"type":"scalar"},"locs":[{"a":147,"b":150}]},{"name":"pageTitle","required":false,"transform":{"type":"scalar"},"locs":[{"a":153,"b":162}]},{"name":"text","required":false,"transform":{"type":"scalar"},"locs":[{"a":165,"b":169}]},{"name":"name","required":false,"transform":{"type":"scalar"},"locs":[{"a":172,"b":176}]},{"name":"email","required":false,"transform":{"type":"scalar"},"locs":[{"a":179,"b":184}]},{"name":"website","required":false,"transform":{"type":"scalar"},"locs":[{"a":187,"b":194}]}],"statement":"INSERT INTO comments(id, account_id, page_url, page_title, comment, reader_name, reader_email, reader_website, created_at) VALUES(:id, :accountId, :url, :pageTitle, :text, :name, :email, :website, 'now'::timestamp)"};
 
 /**
  * Query generated from SQL:
@@ -53,58 +34,32 @@ const postCommentForUrlIR: any = {
  * INSERT INTO comments(id, account_id, page_url, page_title, comment, reader_name, reader_email, reader_website, created_at) VALUES(:id, :accountId, :url, :pageTitle, :text, :name, :email, :website, 'now'::timestamp)
  * ```
  */
-export const postCommentForUrl = new PreparedQuery<IPostCommentForUrlParams, IPostCommentForUrlResult>(
-  postCommentForUrlIR
-)
+export const postCommentForUrl = new PreparedQuery<IPostCommentForUrlParams,IPostCommentForUrlResult>(postCommentForUrlIR);
+
 
 /** 'PostCommentForUrlWithTimestamp' parameters type */
 export interface IPostCommentForUrlWithTimestampParams {
-  accountId: string | null | void
-  createdAt: Date | null | void
-  email: string | null | void
-  id: string | null | void
-  name: string | null | void
-  pageTitle: string | null | void
-  text: string | null | void
-  url: string | null | void
-  website: string | null | void
+  accountId?: string | null | void;
+  createdAt?: DateOrString | null | void;
+  email?: string | null | void;
+  id?: string | null | void;
+  name?: string | null | void;
+  pageTitle?: string | null | void;
+  text?: string | null | void;
+  url?: string | null | void;
+  website?: string | null | void;
 }
 
 /** 'PostCommentForUrlWithTimestamp' return type */
-export type IPostCommentForUrlWithTimestampResult = void
+export type IPostCommentForUrlWithTimestampResult = void;
 
 /** 'PostCommentForUrlWithTimestamp' query type */
 export interface IPostCommentForUrlWithTimestampQuery {
-  params: IPostCommentForUrlWithTimestampParams
-  result: IPostCommentForUrlWithTimestampResult
+  params: IPostCommentForUrlWithTimestampParams;
+  result: IPostCommentForUrlWithTimestampResult;
 }
 
-const postCommentForUrlWithTimestampIR: any = {
-  usedParamSet: {
-    id: true,
-    accountId: true,
-    url: true,
-    pageTitle: true,
-    text: true,
-    name: true,
-    email: true,
-    website: true,
-    createdAt: true,
-  },
-  params: [
-    { name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 130, b: 132 }] },
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 135, b: 144 }] },
-    { name: 'url', required: false, transform: { type: 'scalar' }, locs: [{ a: 147, b: 150 }] },
-    { name: 'pageTitle', required: false, transform: { type: 'scalar' }, locs: [{ a: 153, b: 162 }] },
-    { name: 'text', required: false, transform: { type: 'scalar' }, locs: [{ a: 165, b: 169 }] },
-    { name: 'name', required: false, transform: { type: 'scalar' }, locs: [{ a: 172, b: 176 }] },
-    { name: 'email', required: false, transform: { type: 'scalar' }, locs: [{ a: 179, b: 184 }] },
-    { name: 'website', required: false, transform: { type: 'scalar' }, locs: [{ a: 187, b: 194 }] },
-    { name: 'createdAt', required: false, transform: { type: 'scalar' }, locs: [{ a: 197, b: 206 }] },
-  ],
-  statement:
-    'INSERT INTO comments(id, account_id, page_url, page_title, comment, reader_name, reader_email, reader_website, created_at) VALUES(:id, :accountId, :url, :pageTitle, :text, :name, :email, :website, :createdAt)',
-}
+const postCommentForUrlWithTimestampIR: any = {"usedParamSet":{"id":true,"accountId":true,"url":true,"pageTitle":true,"text":true,"name":true,"email":true,"website":true,"createdAt":true},"params":[{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":130,"b":132}]},{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":135,"b":144}]},{"name":"url","required":false,"transform":{"type":"scalar"},"locs":[{"a":147,"b":150}]},{"name":"pageTitle","required":false,"transform":{"type":"scalar"},"locs":[{"a":153,"b":162}]},{"name":"text","required":false,"transform":{"type":"scalar"},"locs":[{"a":165,"b":169}]},{"name":"name","required":false,"transform":{"type":"scalar"},"locs":[{"a":172,"b":176}]},{"name":"email","required":false,"transform":{"type":"scalar"},"locs":[{"a":179,"b":184}]},{"name":"website","required":false,"transform":{"type":"scalar"},"locs":[{"a":187,"b":194}]},{"name":"createdAt","required":false,"transform":{"type":"scalar"},"locs":[{"a":197,"b":206}]}],"statement":"INSERT INTO comments(id, account_id, page_url, page_title, comment, reader_name, reader_email, reader_website, created_at) VALUES(:id, :accountId, :url, :pageTitle, :text, :name, :email, :website, :createdAt)"};
 
 /**
  * Query generated from SQL:
@@ -112,56 +67,31 @@ const postCommentForUrlWithTimestampIR: any = {
  * INSERT INTO comments(id, account_id, page_url, page_title, comment, reader_name, reader_email, reader_website, created_at) VALUES(:id, :accountId, :url, :pageTitle, :text, :name, :email, :website, :createdAt)
  * ```
  */
-export const postCommentForUrlWithTimestamp = new PreparedQuery<
-  IPostCommentForUrlWithTimestampParams,
-  IPostCommentForUrlWithTimestampResult
->(postCommentForUrlWithTimestampIR)
+export const postCommentForUrlWithTimestamp = new PreparedQuery<IPostCommentForUrlWithTimestampParams,IPostCommentForUrlWithTimestampResult>(postCommentForUrlWithTimestampIR);
+
 
 /** 'FlagCommentForUrl' parameters type */
 export interface IFlagCommentForUrlParams {
-  accountId: string | null | void
-  email: string | null | void
-  id: string | null | void
-  name: string | null | void
-  pageTitle: string | null | void
-  text: string | null | void
-  url: string | null | void
-  website: string | null | void
+  accountId?: string | null | void;
+  email?: string | null | void;
+  id?: string | null | void;
+  name?: string | null | void;
+  pageTitle?: string | null | void;
+  text?: string | null | void;
+  url?: string | null | void;
+  website?: string | null | void;
 }
 
 /** 'FlagCommentForUrl' return type */
-export type IFlagCommentForUrlResult = void
+export type IFlagCommentForUrlResult = void;
 
 /** 'FlagCommentForUrl' query type */
 export interface IFlagCommentForUrlQuery {
-  params: IFlagCommentForUrlParams
-  result: IFlagCommentForUrlResult
+  params: IFlagCommentForUrlParams;
+  result: IFlagCommentForUrlResult;
 }
 
-const flagCommentForUrlIR: any = {
-  usedParamSet: {
-    id: true,
-    accountId: true,
-    url: true,
-    pageTitle: true,
-    text: true,
-    name: true,
-    email: true,
-    website: true,
-  },
-  params: [
-    { name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 129, b: 131 }] },
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 134, b: 143 }] },
-    { name: 'url', required: false, transform: { type: 'scalar' }, locs: [{ a: 146, b: 149 }] },
-    { name: 'pageTitle', required: false, transform: { type: 'scalar' }, locs: [{ a: 151, b: 160 }] },
-    { name: 'text', required: false, transform: { type: 'scalar' }, locs: [{ a: 163, b: 167 }] },
-    { name: 'name', required: false, transform: { type: 'scalar' }, locs: [{ a: 170, b: 174 }] },
-    { name: 'email', required: false, transform: { type: 'scalar' }, locs: [{ a: 177, b: 182 }] },
-    { name: 'website', required: false, transform: { type: 'scalar' }, locs: [{ a: 185, b: 192 }] },
-  ],
-  statement:
-    "INSERT INTO reviews(id, account_id, page_url, page_title, comment, reader_name, reader_email, reader_website, created_at) VALUES(:id, :accountId, :url,:pageTitle, :text, :name, :email, :website, 'now'::timestamp)",
-}
+const flagCommentForUrlIR: any = {"usedParamSet":{"id":true,"accountId":true,"url":true,"pageTitle":true,"text":true,"name":true,"email":true,"website":true},"params":[{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":129,"b":131}]},{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":134,"b":143}]},{"name":"url","required":false,"transform":{"type":"scalar"},"locs":[{"a":146,"b":149}]},{"name":"pageTitle","required":false,"transform":{"type":"scalar"},"locs":[{"a":151,"b":160}]},{"name":"text","required":false,"transform":{"type":"scalar"},"locs":[{"a":163,"b":167}]},{"name":"name","required":false,"transform":{"type":"scalar"},"locs":[{"a":170,"b":174}]},{"name":"email","required":false,"transform":{"type":"scalar"},"locs":[{"a":177,"b":182}]},{"name":"website","required":false,"transform":{"type":"scalar"},"locs":[{"a":185,"b":192}]}],"statement":"INSERT INTO reviews(id, account_id, page_url, page_title, comment, reader_name, reader_email, reader_website, created_at) VALUES(:id, :accountId, :url,:pageTitle, :text, :name, :email, :website, 'now'::timestamp)"};
 
 /**
  * Query generated from SQL:
@@ -169,58 +99,32 @@ const flagCommentForUrlIR: any = {
  * INSERT INTO reviews(id, account_id, page_url, page_title, comment, reader_name, reader_email, reader_website, created_at) VALUES(:id, :accountId, :url,:pageTitle, :text, :name, :email, :website, 'now'::timestamp)
  * ```
  */
-export const flagCommentForUrl = new PreparedQuery<IFlagCommentForUrlParams, IFlagCommentForUrlResult>(
-  flagCommentForUrlIR
-)
+export const flagCommentForUrl = new PreparedQuery<IFlagCommentForUrlParams,IFlagCommentForUrlResult>(flagCommentForUrlIR);
+
 
 /** 'FlagCommentForUrlWithTimestamp' parameters type */
 export interface IFlagCommentForUrlWithTimestampParams {
-  accountId: string | null | void
-  createdAt: Date | null | void
-  email: string | null | void
-  id: string | null | void
-  name: string | null | void
-  pageTitle: string | null | void
-  text: string | null | void
-  url: string | null | void
-  website: string | null | void
+  accountId?: string | null | void;
+  createdAt?: DateOrString | null | void;
+  email?: string | null | void;
+  id?: string | null | void;
+  name?: string | null | void;
+  pageTitle?: string | null | void;
+  text?: string | null | void;
+  url?: string | null | void;
+  website?: string | null | void;
 }
 
 /** 'FlagCommentForUrlWithTimestamp' return type */
-export type IFlagCommentForUrlWithTimestampResult = void
+export type IFlagCommentForUrlWithTimestampResult = void;
 
 /** 'FlagCommentForUrlWithTimestamp' query type */
 export interface IFlagCommentForUrlWithTimestampQuery {
-  params: IFlagCommentForUrlWithTimestampParams
-  result: IFlagCommentForUrlWithTimestampResult
+  params: IFlagCommentForUrlWithTimestampParams;
+  result: IFlagCommentForUrlWithTimestampResult;
 }
 
-const flagCommentForUrlWithTimestampIR: any = {
-  usedParamSet: {
-    id: true,
-    accountId: true,
-    url: true,
-    pageTitle: true,
-    text: true,
-    name: true,
-    email: true,
-    website: true,
-    createdAt: true,
-  },
-  params: [
-    { name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 129, b: 131 }] },
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 134, b: 143 }] },
-    { name: 'url', required: false, transform: { type: 'scalar' }, locs: [{ a: 146, b: 149 }] },
-    { name: 'pageTitle', required: false, transform: { type: 'scalar' }, locs: [{ a: 151, b: 160 }] },
-    { name: 'text', required: false, transform: { type: 'scalar' }, locs: [{ a: 163, b: 167 }] },
-    { name: 'name', required: false, transform: { type: 'scalar' }, locs: [{ a: 170, b: 174 }] },
-    { name: 'email', required: false, transform: { type: 'scalar' }, locs: [{ a: 177, b: 182 }] },
-    { name: 'website', required: false, transform: { type: 'scalar' }, locs: [{ a: 185, b: 192 }] },
-    { name: 'createdAt', required: false, transform: { type: 'scalar' }, locs: [{ a: 195, b: 204 }] },
-  ],
-  statement:
-    'INSERT INTO reviews(id, account_id, page_url, page_title, comment, reader_name, reader_email, reader_website, created_at) VALUES(:id, :accountId, :url,:pageTitle, :text, :name, :email, :website, :createdAt)',
-}
+const flagCommentForUrlWithTimestampIR: any = {"usedParamSet":{"id":true,"accountId":true,"url":true,"pageTitle":true,"text":true,"name":true,"email":true,"website":true,"createdAt":true},"params":[{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":129,"b":131}]},{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":134,"b":143}]},{"name":"url","required":false,"transform":{"type":"scalar"},"locs":[{"a":146,"b":149}]},{"name":"pageTitle","required":false,"transform":{"type":"scalar"},"locs":[{"a":151,"b":160}]},{"name":"text","required":false,"transform":{"type":"scalar"},"locs":[{"a":163,"b":167}]},{"name":"name","required":false,"transform":{"type":"scalar"},"locs":[{"a":170,"b":174}]},{"name":"email","required":false,"transform":{"type":"scalar"},"locs":[{"a":177,"b":182}]},{"name":"website","required":false,"transform":{"type":"scalar"},"locs":[{"a":185,"b":192}]},{"name":"createdAt","required":false,"transform":{"type":"scalar"},"locs":[{"a":195,"b":204}]}],"statement":"INSERT INTO reviews(id, account_id, page_url, page_title, comment, reader_name, reader_email, reader_website, created_at) VALUES(:id, :accountId, :url,:pageTitle, :text, :name, :email, :website, :createdAt)"};
 
 /**
  * Query generated from SQL:
@@ -228,32 +132,26 @@ const flagCommentForUrlWithTimestampIR: any = {
  * INSERT INTO reviews(id, account_id, page_url, page_title, comment, reader_name, reader_email, reader_website, created_at) VALUES(:id, :accountId, :url,:pageTitle, :text, :name, :email, :website, :createdAt)
  * ```
  */
-export const flagCommentForUrlWithTimestamp = new PreparedQuery<
-  IFlagCommentForUrlWithTimestampParams,
-  IFlagCommentForUrlWithTimestampResult
->(flagCommentForUrlWithTimestampIR)
+export const flagCommentForUrlWithTimestamp = new PreparedQuery<IFlagCommentForUrlWithTimestampParams,IFlagCommentForUrlWithTimestampResult>(flagCommentForUrlWithTimestampIR);
+
 
 /** 'CommentCountForAccount' parameters type */
 export interface ICommentCountForAccountParams {
-  accountId: string | null | void
+  accountId?: string | null | void;
 }
 
 /** 'CommentCountForAccount' return type */
 export interface ICommentCountForAccountResult {
-  Total: string | null
+  Total: string | null;
 }
 
 /** 'CommentCountForAccount' query type */
 export interface ICommentCountForAccountQuery {
-  params: ICommentCountForAccountParams
-  result: ICommentCountForAccountResult
+  params: ICommentCountForAccountParams;
+  result: ICommentCountForAccountResult;
 }
 
-const commentCountForAccountIR: any = {
-  usedParamSet: { accountId: true },
-  params: [{ name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 58, b: 67 }] }],
-  statement: 'SELECT COUNT(*) as "Total" FROM comments WHERE account_id=:accountId',
-}
+const commentCountForAccountIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":58,"b":67}]}],"statement":"SELECT COUNT(*) as \"Total\" FROM comments WHERE account_id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -261,31 +159,26 @@ const commentCountForAccountIR: any = {
  * SELECT COUNT(*) as "Total" FROM comments WHERE account_id=:accountId
  * ```
  */
-export const commentCountForAccount = new PreparedQuery<ICommentCountForAccountParams, ICommentCountForAccountResult>(
-  commentCountForAccountIR
-)
+export const commentCountForAccount = new PreparedQuery<ICommentCountForAccountParams,ICommentCountForAccountResult>(commentCountForAccountIR);
+
 
 /** 'ReviewCountForAccount' parameters type */
 export interface IReviewCountForAccountParams {
-  accountId: string | null | void
+  accountId?: string | null | void;
 }
 
 /** 'ReviewCountForAccount' return type */
 export interface IReviewCountForAccountResult {
-  Total: string | null
+  Total: string | null;
 }
 
 /** 'ReviewCountForAccount' query type */
 export interface IReviewCountForAccountQuery {
-  params: IReviewCountForAccountParams
-  result: IReviewCountForAccountResult
+  params: IReviewCountForAccountParams;
+  result: IReviewCountForAccountResult;
 }
 
-const reviewCountForAccountIR: any = {
-  usedParamSet: { accountId: true },
-  params: [{ name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 57, b: 66 }] }],
-  statement: 'SELECT COUNT(*) as "Total" FROM reviews WHERE account_id=:accountId',
-}
+const reviewCountForAccountIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":57,"b":66}]}],"statement":"SELECT COUNT(*) as \"Total\" FROM reviews WHERE account_id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -293,43 +186,35 @@ const reviewCountForAccountIR: any = {
  * SELECT COUNT(*) as "Total" FROM reviews WHERE account_id=:accountId
  * ```
  */
-export const reviewCountForAccount = new PreparedQuery<IReviewCountForAccountParams, IReviewCountForAccountResult>(
-  reviewCountForAccountIR
-)
+export const reviewCountForAccount = new PreparedQuery<IReviewCountForAccountParams,IReviewCountForAccountResult>(reviewCountForAccountIR);
+
 
 /** 'FindByIdForAccount' parameters type */
 export interface IFindByIdForAccountParams {
-  accountId: string | null | void
-  id: string | null | void
+  accountId?: string | null | void;
+  id?: string | null | void;
 }
 
 /** 'FindByIdForAccount' return type */
 export interface IFindByIdForAccountResult {
-  account_id: string
-  comment: string
-  created_at: Date
-  id: string
-  page_title: string | null
-  page_url: string
-  reader_email: string | null
-  reader_name: string
-  reader_website: string | null
+  account_id: string;
+  comment: string;
+  created_at: Date;
+  id: string;
+  page_title: string | null;
+  page_url: string;
+  reader_email: string | null;
+  reader_name: string;
+  reader_website: string | null;
 }
 
 /** 'FindByIdForAccount' query type */
 export interface IFindByIdForAccountQuery {
-  params: IFindByIdForAccountParams
-  result: IFindByIdForAccountResult
+  params: IFindByIdForAccountParams;
+  result: IFindByIdForAccountResult;
 }
 
-const findByIdForAccountIR: any = {
-  usedParamSet: { accountId: true, id: true },
-  params: [
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 40, b: 49 }] },
-    { name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 58, b: 60 }] },
-  ],
-  statement: 'SELECT * FROM comments WHERE account_id=:accountId AND id=:id',
-}
+const findByIdForAccountIR: any = {"usedParamSet":{"accountId":true,"id":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":40,"b":49}]},{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":58,"b":60}]}],"statement":"SELECT * FROM comments WHERE account_id=:accountId AND id=:id"};
 
 /**
  * Query generated from SQL:
@@ -337,39 +222,34 @@ const findByIdForAccountIR: any = {
  * SELECT * FROM comments WHERE account_id=:accountId AND id=:id
  * ```
  */
-export const findByIdForAccount = new PreparedQuery<IFindByIdForAccountParams, IFindByIdForAccountResult>(
-  findByIdForAccountIR
-)
+export const findByIdForAccount = new PreparedQuery<IFindByIdForAccountParams,IFindByIdForAccountResult>(findByIdForAccountIR);
+
 
 /** 'CommentsForAccount' parameters type */
 export interface ICommentsForAccountParams {
-  accountId: string | null | void
+  accountId?: string | null | void;
 }
 
 /** 'CommentsForAccount' return type */
 export interface ICommentsForAccountResult {
-  account_id: string
-  comment: string
-  created_at: Date
-  id: string
-  page_title: string | null
-  page_url: string
-  reader_email: string | null
-  reader_name: string
-  reader_website: string | null
+  account_id: string;
+  comment: string;
+  created_at: Date;
+  id: string;
+  page_title: string | null;
+  page_url: string;
+  reader_email: string | null;
+  reader_name: string;
+  reader_website: string | null;
 }
 
 /** 'CommentsForAccount' query type */
 export interface ICommentsForAccountQuery {
-  params: ICommentsForAccountParams
-  result: ICommentsForAccountResult
+  params: ICommentsForAccountParams;
+  result: ICommentsForAccountResult;
 }
 
-const commentsForAccountIR: any = {
-  usedParamSet: { accountId: true },
-  params: [{ name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 40, b: 49 }] }],
-  statement: 'SELECT * FROM comments WHERE account_id=:accountId ORDER BY created_at DESC',
-}
+const commentsForAccountIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":40,"b":49}]}],"statement":"SELECT * FROM comments WHERE account_id=:accountId ORDER BY created_at DESC"};
 
 /**
  * Query generated from SQL:
@@ -377,48 +257,37 @@ const commentsForAccountIR: any = {
  * SELECT * FROM comments WHERE account_id=:accountId ORDER BY created_at DESC
  * ```
  */
-export const commentsForAccount = new PreparedQuery<ICommentsForAccountParams, ICommentsForAccountResult>(
-  commentsForAccountIR
-)
+export const commentsForAccount = new PreparedQuery<ICommentsForAccountParams,ICommentsForAccountResult>(commentsForAccountIR);
+
 
 /** 'CommentsForAccountPaged' parameters type */
 export interface ICommentsForAccountPagedParams {
-  accountId: string | null | void
-  asc: boolean | null | void
-  limit: string | null | void
-  offset: string | null | void
+  accountId?: string | null | void;
+  asc?: boolean | null | void;
+  limit?: NumberOrString | null | void;
+  offset?: NumberOrString | null | void;
 }
 
 /** 'CommentsForAccountPaged' return type */
 export interface ICommentsForAccountPagedResult {
-  account_id: string
-  comment: string
-  created_at: Date
-  id: string
-  page_title: string | null
-  page_url: string
-  reader_email: string | null
-  reader_name: string
-  reader_website: string | null
+  account_id: string;
+  comment: string;
+  created_at: Date;
+  id: string;
+  page_title: string | null;
+  page_url: string;
+  reader_email: string | null;
+  reader_name: string;
+  reader_website: string | null;
 }
 
 /** 'CommentsForAccountPaged' query type */
 export interface ICommentsForAccountPagedQuery {
-  params: ICommentsForAccountPagedParams
-  result: ICommentsForAccountPagedResult
+  params: ICommentsForAccountPagedParams;
+  result: ICommentsForAccountPagedResult;
 }
 
-const commentsForAccountPagedIR: any = {
-  usedParamSet: { accountId: true, asc: true, limit: true, offset: true },
-  params: [
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 40, b: 49 }] },
-    { name: 'asc', required: false, transform: { type: 'scalar' }, locs: [{ a: 71, b: 74 }] },
-    { name: 'limit', required: false, transform: { type: 'scalar' }, locs: [{ a: 131, b: 136 }] },
-    { name: 'offset', required: false, transform: { type: 'scalar' }, locs: [{ a: 145, b: 151 }] },
-  ],
-  statement:
-    'SELECT * FROM comments WHERE account_id=:accountId ORDER BY (CASE WHEN :asc = true THEN created_at END) ASC, created_at DESC LIMIT :limit OFFSET :offset',
-}
+const commentsForAccountPagedIR: any = {"usedParamSet":{"accountId":true,"asc":true,"limit":true,"offset":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":40,"b":49}]},{"name":"asc","required":false,"transform":{"type":"scalar"},"locs":[{"a":71,"b":74}]},{"name":"limit","required":false,"transform":{"type":"scalar"},"locs":[{"a":131,"b":136}]},{"name":"offset","required":false,"transform":{"type":"scalar"},"locs":[{"a":145,"b":151}]}],"statement":"SELECT * FROM comments WHERE account_id=:accountId ORDER BY (CASE WHEN :asc = true THEN created_at END) ASC, created_at DESC LIMIT :limit OFFSET :offset"};
 
 /**
  * Query generated from SQL:
@@ -426,44 +295,35 @@ const commentsForAccountPagedIR: any = {
  * SELECT * FROM comments WHERE account_id=:accountId ORDER BY (CASE WHEN :asc = true THEN created_at END) ASC, created_at DESC LIMIT :limit OFFSET :offset
  * ```
  */
-export const commentsForAccountPaged = new PreparedQuery<
-  ICommentsForAccountPagedParams,
-  ICommentsForAccountPagedResult
->(commentsForAccountPagedIR)
+export const commentsForAccountPaged = new PreparedQuery<ICommentsForAccountPagedParams,ICommentsForAccountPagedResult>(commentsForAccountPagedIR);
+
 
 /** 'FindSpamByIdForAccount' parameters type */
 export interface IFindSpamByIdForAccountParams {
-  accountId: string | null | void
-  id: string | null | void
+  accountId?: string | null | void;
+  id?: string | null | void;
 }
 
 /** 'FindSpamByIdForAccount' return type */
 export interface IFindSpamByIdForAccountResult {
-  account_id: string
-  comment: string
-  created_at: Date
-  id: string
-  page_title: string | null
-  page_url: string
-  reader_email: string | null
-  reader_name: string
-  reader_website: string | null
+  account_id: string;
+  comment: string;
+  created_at: Date;
+  id: string;
+  page_title: string | null;
+  page_url: string;
+  reader_email: string | null;
+  reader_name: string;
+  reader_website: string | null;
 }
 
 /** 'FindSpamByIdForAccount' query type */
 export interface IFindSpamByIdForAccountQuery {
-  params: IFindSpamByIdForAccountParams
-  result: IFindSpamByIdForAccountResult
+  params: IFindSpamByIdForAccountParams;
+  result: IFindSpamByIdForAccountResult;
 }
 
-const findSpamByIdForAccountIR: any = {
-  usedParamSet: { accountId: true, id: true },
-  params: [
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 39, b: 48 }] },
-    { name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 57, b: 59 }] },
-  ],
-  statement: 'SELECT * FROM reviews WHERE account_id=:accountId AND id=:id',
-}
+const findSpamByIdForAccountIR: any = {"usedParamSet":{"accountId":true,"id":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":39,"b":48}]},{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":57,"b":59}]}],"statement":"SELECT * FROM reviews WHERE account_id=:accountId AND id=:id"};
 
 /**
  * Query generated from SQL:
@@ -471,39 +331,34 @@ const findSpamByIdForAccountIR: any = {
  * SELECT * FROM reviews WHERE account_id=:accountId AND id=:id
  * ```
  */
-export const findSpamByIdForAccount = new PreparedQuery<IFindSpamByIdForAccountParams, IFindSpamByIdForAccountResult>(
-  findSpamByIdForAccountIR
-)
+export const findSpamByIdForAccount = new PreparedQuery<IFindSpamByIdForAccountParams,IFindSpamByIdForAccountResult>(findSpamByIdForAccountIR);
+
 
 /** 'ReviewsForAccount' parameters type */
 export interface IReviewsForAccountParams {
-  accountId: string | null | void
+  accountId?: string | null | void;
 }
 
 /** 'ReviewsForAccount' return type */
 export interface IReviewsForAccountResult {
-  account_id: string
-  comment: string
-  created_at: Date
-  id: string
-  page_title: string | null
-  page_url: string
-  reader_email: string | null
-  reader_name: string
-  reader_website: string | null
+  account_id: string;
+  comment: string;
+  created_at: Date;
+  id: string;
+  page_title: string | null;
+  page_url: string;
+  reader_email: string | null;
+  reader_name: string;
+  reader_website: string | null;
 }
 
 /** 'ReviewsForAccount' query type */
 export interface IReviewsForAccountQuery {
-  params: IReviewsForAccountParams
-  result: IReviewsForAccountResult
+  params: IReviewsForAccountParams;
+  result: IReviewsForAccountResult;
 }
 
-const reviewsForAccountIR: any = {
-  usedParamSet: { accountId: true },
-  params: [{ name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 39, b: 48 }] }],
-  statement: 'SELECT * FROM reviews WHERE account_id=:accountId ORDER BY created_at DESC',
-}
+const reviewsForAccountIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":39,"b":48}]}],"statement":"SELECT * FROM reviews WHERE account_id=:accountId ORDER BY created_at DESC"};
 
 /**
  * Query generated from SQL:
@@ -511,48 +366,37 @@ const reviewsForAccountIR: any = {
  * SELECT * FROM reviews WHERE account_id=:accountId ORDER BY created_at DESC
  * ```
  */
-export const reviewsForAccount = new PreparedQuery<IReviewsForAccountParams, IReviewsForAccountResult>(
-  reviewsForAccountIR
-)
+export const reviewsForAccount = new PreparedQuery<IReviewsForAccountParams,IReviewsForAccountResult>(reviewsForAccountIR);
+
 
 /** 'ReviewsForAccountPaged' parameters type */
 export interface IReviewsForAccountPagedParams {
-  accountId: string | null | void
-  asc: boolean | null | void
-  limit: string | null | void
-  offset: string | null | void
+  accountId?: string | null | void;
+  asc?: boolean | null | void;
+  limit?: NumberOrString | null | void;
+  offset?: NumberOrString | null | void;
 }
 
 /** 'ReviewsForAccountPaged' return type */
 export interface IReviewsForAccountPagedResult {
-  account_id: string
-  comment: string
-  created_at: Date
-  id: string
-  page_title: string | null
-  page_url: string
-  reader_email: string | null
-  reader_name: string
-  reader_website: string | null
+  account_id: string;
+  comment: string;
+  created_at: Date;
+  id: string;
+  page_title: string | null;
+  page_url: string;
+  reader_email: string | null;
+  reader_name: string;
+  reader_website: string | null;
 }
 
 /** 'ReviewsForAccountPaged' query type */
 export interface IReviewsForAccountPagedQuery {
-  params: IReviewsForAccountPagedParams
-  result: IReviewsForAccountPagedResult
+  params: IReviewsForAccountPagedParams;
+  result: IReviewsForAccountPagedResult;
 }
 
-const reviewsForAccountPagedIR: any = {
-  usedParamSet: { accountId: true, asc: true, limit: true, offset: true },
-  params: [
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 39, b: 48 }] },
-    { name: 'asc', required: false, transform: { type: 'scalar' }, locs: [{ a: 70, b: 73 }] },
-    { name: 'limit', required: false, transform: { type: 'scalar' }, locs: [{ a: 130, b: 135 }] },
-    { name: 'offset', required: false, transform: { type: 'scalar' }, locs: [{ a: 144, b: 150 }] },
-  ],
-  statement:
-    'SELECT * FROM reviews WHERE account_id=:accountId ORDER BY (CASE WHEN :asc = true THEN created_at END) ASC, created_at DESC LIMIT :limit OFFSET :offset',
-}
+const reviewsForAccountPagedIR: any = {"usedParamSet":{"accountId":true,"asc":true,"limit":true,"offset":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":39,"b":48}]},{"name":"asc","required":false,"transform":{"type":"scalar"},"locs":[{"a":70,"b":73}]},{"name":"limit","required":false,"transform":{"type":"scalar"},"locs":[{"a":130,"b":135}]},{"name":"offset","required":false,"transform":{"type":"scalar"},"locs":[{"a":144,"b":150}]}],"statement":"SELECT * FROM reviews WHERE account_id=:accountId ORDER BY (CASE WHEN :asc = true THEN created_at END) ASC, created_at DESC LIMIT :limit OFFSET :offset"};
 
 /**
  * Query generated from SQL:
@@ -560,43 +404,35 @@ const reviewsForAccountPagedIR: any = {
  * SELECT * FROM reviews WHERE account_id=:accountId ORDER BY (CASE WHEN :asc = true THEN created_at END) ASC, created_at DESC LIMIT :limit OFFSET :offset
  * ```
  */
-export const reviewsForAccountPaged = new PreparedQuery<IReviewsForAccountPagedParams, IReviewsForAccountPagedResult>(
-  reviewsForAccountPagedIR
-)
+export const reviewsForAccountPaged = new PreparedQuery<IReviewsForAccountPagedParams,IReviewsForAccountPagedResult>(reviewsForAccountPagedIR);
+
 
 /** 'CommentsForUrl' parameters type */
 export interface ICommentsForUrlParams {
-  accountId: string | null | void
-  url: string | null | void
+  accountId?: string | null | void;
+  url?: string | null | void;
 }
 
 /** 'CommentsForUrl' return type */
 export interface ICommentsForUrlResult {
-  account_id: string
-  comment: string
-  created_at: Date
-  id: string
-  page_title: string | null
-  page_url: string
-  reader_email: string | null
-  reader_name: string
-  reader_website: string | null
+  account_id: string;
+  comment: string;
+  created_at: Date;
+  id: string;
+  page_title: string | null;
+  page_url: string;
+  reader_email: string | null;
+  reader_name: string;
+  reader_website: string | null;
 }
 
 /** 'CommentsForUrl' query type */
 export interface ICommentsForUrlQuery {
-  params: ICommentsForUrlParams
-  result: ICommentsForUrlResult
+  params: ICommentsForUrlParams;
+  result: ICommentsForUrlResult;
 }
 
-const commentsForUrlIR: any = {
-  usedParamSet: { accountId: true, url: true },
-  params: [
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 40, b: 49 }] },
-    { name: 'url', required: false, transform: { type: 'scalar' }, locs: [{ a: 64, b: 67 }] },
-  ],
-  statement: 'SELECT * FROM comments WHERE account_id=:accountId AND page_url=:url ORDER BY created_at ASC',
-}
+const commentsForUrlIR: any = {"usedParamSet":{"accountId":true,"url":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":40,"b":49}]},{"name":"url","required":false,"transform":{"type":"scalar"},"locs":[{"a":64,"b":67}]}],"statement":"SELECT * FROM comments WHERE account_id=:accountId AND page_url=:url ORDER BY created_at ASC"};
 
 /**
  * Query generated from SQL:
@@ -604,44 +440,36 @@ const commentsForUrlIR: any = {
  * SELECT * FROM comments WHERE account_id=:accountId AND page_url=:url ORDER BY created_at ASC
  * ```
  */
-export const commentsForUrl = new PreparedQuery<ICommentsForUrlParams, ICommentsForUrlResult>(commentsForUrlIR)
+export const commentsForUrl = new PreparedQuery<ICommentsForUrlParams,ICommentsForUrlResult>(commentsForUrlIR);
+
 
 /** 'CommentsForUrlSinceDate' parameters type */
 export interface ICommentsForUrlSinceDateParams {
-  accountId: string | null | void
-  date: Date | null | void
-  url: string | null | void
+  accountId?: string | null | void;
+  date?: DateOrString | null | void;
+  url?: string | null | void;
 }
 
 /** 'CommentsForUrlSinceDate' return type */
 export interface ICommentsForUrlSinceDateResult {
-  account_id: string
-  comment: string
-  created_at: Date
-  id: string
-  page_title: string | null
-  page_url: string
-  reader_email: string | null
-  reader_name: string
-  reader_website: string | null
+  account_id: string;
+  comment: string;
+  created_at: Date;
+  id: string;
+  page_title: string | null;
+  page_url: string;
+  reader_email: string | null;
+  reader_name: string;
+  reader_website: string | null;
 }
 
 /** 'CommentsForUrlSinceDate' query type */
 export interface ICommentsForUrlSinceDateQuery {
-  params: ICommentsForUrlSinceDateParams
-  result: ICommentsForUrlSinceDateResult
+  params: ICommentsForUrlSinceDateParams;
+  result: ICommentsForUrlSinceDateResult;
 }
 
-const commentsForUrlSinceDateIR: any = {
-  usedParamSet: { accountId: true, url: true, date: true },
-  params: [
-    { name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 40, b: 49 }] },
-    { name: 'url', required: false, transform: { type: 'scalar' }, locs: [{ a: 64, b: 67 }] },
-    { name: 'date', required: false, transform: { type: 'scalar' }, locs: [{ a: 86, b: 90 }] },
-  ],
-  statement:
-    'SELECT * FROM comments WHERE account_id=:accountId AND page_url=:url AND created_at > :date ORDER BY created_at ASC',
-}
+const commentsForUrlSinceDateIR: any = {"usedParamSet":{"accountId":true,"url":true,"date":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":40,"b":49}]},{"name":"url","required":false,"transform":{"type":"scalar"},"locs":[{"a":64,"b":67}]},{"name":"date","required":false,"transform":{"type":"scalar"},"locs":[{"a":86,"b":90}]}],"statement":"SELECT * FROM comments WHERE account_id=:accountId AND page_url=:url AND created_at > :date ORDER BY created_at ASC"};
 
 /**
  * Query generated from SQL:
@@ -649,30 +477,24 @@ const commentsForUrlSinceDateIR: any = {
  * SELECT * FROM comments WHERE account_id=:accountId AND page_url=:url AND created_at > :date ORDER BY created_at ASC
  * ```
  */
-export const commentsForUrlSinceDate = new PreparedQuery<
-  ICommentsForUrlSinceDateParams,
-  ICommentsForUrlSinceDateResult
->(commentsForUrlSinceDateIR)
+export const commentsForUrlSinceDate = new PreparedQuery<ICommentsForUrlSinceDateParams,ICommentsForUrlSinceDateResult>(commentsForUrlSinceDateIR);
+
 
 /** 'DeleteSingleComment' parameters type */
 export interface IDeleteSingleCommentParams {
-  id: string | null | void
+  id?: string | null | void;
 }
 
 /** 'DeleteSingleComment' return type */
-export type IDeleteSingleCommentResult = void
+export type IDeleteSingleCommentResult = void;
 
 /** 'DeleteSingleComment' query type */
 export interface IDeleteSingleCommentQuery {
-  params: IDeleteSingleCommentParams
-  result: IDeleteSingleCommentResult
+  params: IDeleteSingleCommentParams;
+  result: IDeleteSingleCommentResult;
 }
 
-const deleteSingleCommentIR: any = {
-  usedParamSet: { id: true },
-  params: [{ name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 30, b: 32 }] }],
-  statement: 'DELETE FROM comments WHERE id=:id',
-}
+const deleteSingleCommentIR: any = {"usedParamSet":{"id":true},"params":[{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":30,"b":32}]}],"statement":"DELETE FROM comments WHERE id=:id"};
 
 /**
  * Query generated from SQL:
@@ -680,29 +502,24 @@ const deleteSingleCommentIR: any = {
  * DELETE FROM comments WHERE id=:id
  * ```
  */
-export const deleteSingleComment = new PreparedQuery<IDeleteSingleCommentParams, IDeleteSingleCommentResult>(
-  deleteSingleCommentIR
-)
+export const deleteSingleComment = new PreparedQuery<IDeleteSingleCommentParams,IDeleteSingleCommentResult>(deleteSingleCommentIR);
+
 
 /** 'DeleteSingleSpam' parameters type */
 export interface IDeleteSingleSpamParams {
-  id: string | null | void
+  id?: string | null | void;
 }
 
 /** 'DeleteSingleSpam' return type */
-export type IDeleteSingleSpamResult = void
+export type IDeleteSingleSpamResult = void;
 
 /** 'DeleteSingleSpam' query type */
 export interface IDeleteSingleSpamQuery {
-  params: IDeleteSingleSpamParams
-  result: IDeleteSingleSpamResult
+  params: IDeleteSingleSpamParams;
+  result: IDeleteSingleSpamResult;
 }
 
-const deleteSingleSpamIR: any = {
-  usedParamSet: { id: true },
-  params: [{ name: 'id', required: false, transform: { type: 'scalar' }, locs: [{ a: 29, b: 31 }] }],
-  statement: 'DELETE FROM reviews WHERE id=:id',
-}
+const deleteSingleSpamIR: any = {"usedParamSet":{"id":true},"params":[{"name":"id","required":false,"transform":{"type":"scalar"},"locs":[{"a":29,"b":31}]}],"statement":"DELETE FROM reviews WHERE id=:id"};
 
 /**
  * Query generated from SQL:
@@ -710,27 +527,24 @@ const deleteSingleSpamIR: any = {
  * DELETE FROM reviews WHERE id=:id
  * ```
  */
-export const deleteSingleSpam = new PreparedQuery<IDeleteSingleSpamParams, IDeleteSingleSpamResult>(deleteSingleSpamIR)
+export const deleteSingleSpam = new PreparedQuery<IDeleteSingleSpamParams,IDeleteSingleSpamResult>(deleteSingleSpamIR);
+
 
 /** 'DeleteAllComments' parameters type */
 export interface IDeleteAllCommentsParams {
-  accountId: string | null | void
+  accountId?: string | null | void;
 }
 
 /** 'DeleteAllComments' return type */
-export type IDeleteAllCommentsResult = void
+export type IDeleteAllCommentsResult = void;
 
 /** 'DeleteAllComments' query type */
 export interface IDeleteAllCommentsQuery {
-  params: IDeleteAllCommentsParams
-  result: IDeleteAllCommentsResult
+  params: IDeleteAllCommentsParams;
+  result: IDeleteAllCommentsResult;
 }
 
-const deleteAllCommentsIR: any = {
-  usedParamSet: { accountId: true },
-  params: [{ name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 38, b: 47 }] }],
-  statement: 'DELETE FROM comments WHERE account_id=:accountId',
-}
+const deleteAllCommentsIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":38,"b":47}]}],"statement":"DELETE FROM comments WHERE account_id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -738,29 +552,24 @@ const deleteAllCommentsIR: any = {
  * DELETE FROM comments WHERE account_id=:accountId
  * ```
  */
-export const deleteAllComments = new PreparedQuery<IDeleteAllCommentsParams, IDeleteAllCommentsResult>(
-  deleteAllCommentsIR
-)
+export const deleteAllComments = new PreparedQuery<IDeleteAllCommentsParams,IDeleteAllCommentsResult>(deleteAllCommentsIR);
+
 
 /** 'DeleteAllSpam' parameters type */
 export interface IDeleteAllSpamParams {
-  accountId: string | null | void
+  accountId?: string | null | void;
 }
 
 /** 'DeleteAllSpam' return type */
-export type IDeleteAllSpamResult = void
+export type IDeleteAllSpamResult = void;
 
 /** 'DeleteAllSpam' query type */
 export interface IDeleteAllSpamQuery {
-  params: IDeleteAllSpamParams
-  result: IDeleteAllSpamResult
+  params: IDeleteAllSpamParams;
+  result: IDeleteAllSpamResult;
 }
 
-const deleteAllSpamIR: any = {
-  usedParamSet: { accountId: true },
-  params: [{ name: 'accountId', required: false, transform: { type: 'scalar' }, locs: [{ a: 37, b: 46 }] }],
-  statement: 'DELETE FROM reviews WHERE account_id=:accountId',
-}
+const deleteAllSpamIR: any = {"usedParamSet":{"accountId":true},"params":[{"name":"accountId","required":false,"transform":{"type":"scalar"},"locs":[{"a":37,"b":46}]}],"statement":"DELETE FROM reviews WHERE account_id=:accountId"};
 
 /**
  * Query generated from SQL:
@@ -768,4 +577,6 @@ const deleteAllSpamIR: any = {
  * DELETE FROM reviews WHERE account_id=:accountId
  * ```
  */
-export const deleteAllSpam = new PreparedQuery<IDeleteAllSpamParams, IDeleteAllSpamResult>(deleteAllSpamIR)
+export const deleteAllSpam = new PreparedQuery<IDeleteAllSpamParams,IDeleteAllSpamResult>(deleteAllSpamIR);
+
+

--- a/src/shared/emails/email.service.spec.ts
+++ b/src/shared/emails/email.service.spec.ts
@@ -1,0 +1,33 @@
+import { Comment } from "../comments/comment.interface"
+import { EmailService } from "./email.service"
+
+describe('Email Service', () => {
+    const emailSvc = new EmailService()
+    const comment: Comment = {
+        id: "foo",
+        account: {
+            id: "bar",
+            username: "tester",
+            email: "test@test.com",
+            createdAt: new Date(),
+        },
+        author: {
+            name: "John Doe",
+            email: "john.doe@test.com",
+            website: "http://johndoe.com"
+        },
+        postUrl: "http://test.com/post",
+        text: "This is a test comment",
+        postedAt: new Date(),
+    }
+
+    it('should include comment ID in the output', () => {
+        const result = emailSvc.notifyOnSingleComment(
+            comment,
+            'https://foobar.com/dashboard/123'
+        )
+
+        expect(result.text).toContain(comment.id)
+        expect(result.html).toContain(comment.id)
+    })
+})

--- a/src/shared/emails/email.service.ts
+++ b/src/shared/emails/email.service.ts
@@ -1,4 +1,4 @@
-import { CommentDto } from '../comments/comment.interface'
+import { CommentWithId } from '../comments/comment.interface'
 import { Email } from './email.interface'
 import handlebars from 'handlebars'
 import { Injectable } from '@nestjs/common'
@@ -16,11 +16,11 @@ export class EmailService {
     }
   }
 
-  notifyOnSingleComment(comment: CommentDto, link: string): Email {
+  notifyOnSingleComment(comment: CommentWithId, link: string): Email {
     const htmlTemplate = handlebars.compile(readFileSync(`${__dirname}/views/comments/single/html.hbs`).toString())
     const textTemplate = handlebars.compile(readFileSync(`${__dirname}/views/comments/single/text.hbs`).toString())
     return {
-      subject: 'A new comment came in to your JamComments',
+      subject: 'A new comment came in to your JComments',
       html: htmlTemplate({ comment, link }),
       text: textTemplate({ comment, link }),
     }

--- a/src/shared/emails/views/comments/single/html.hbs
+++ b/src/shared/emails/views/comments/single/html.hbs
@@ -17,4 +17,4 @@
 
 <hr/>
 
-<p>Looks fishy? You can always delete it using your <a href="{{ link }}">dashboard</a></p>
+<p>Looks fishy? You can always delete it using your <a href="{{ link }}">dashboard</a> or CLI - {{ comment.id }}</p>

--- a/src/shared/emails/views/comments/single/text.hbs
+++ b/src/shared/emails/views/comments/single/text.hbs
@@ -15,4 +15,4 @@ Web: {{ comment.author.website }}
 {{ comment.text }}
 ---
 
-Looks fishy? You can always delete it using your dashboard - {{ link }}
+Looks fishy? You can always delete it using your dashboard - {{ link }} or CLI - {{ comment.id }}

--- a/src/web/account.controller.ts
+++ b/src/web/account.controller.ts
@@ -83,7 +83,7 @@ export class AccountController {
       layout: 'dashboard',
       section: 'Settings',
       csrfToken: req.csrfToken(),
-      token: await this.accountService.token(account),
+      token: await this.accountService.lastToken(account),
       account,
       changeEmailError: req.flash('change-email-error'),
       ...settings,
@@ -134,7 +134,7 @@ export class AccountController {
   @UseGuards(AuthenticatedGuard)
   async refreshToken(@Req() req: Request, @Res() res: Response): Promise<Response> {
     const account = _.get(req, 'user') as Account
-    const token = await this.accountService.token(account)
+    const token = await this.accountService.lastToken(account)
     if (!token) {
       this.logger.error('No token found, none revoked')
       return res.status(400).json({ error: 'Could not reissue API token' })
@@ -143,7 +143,7 @@ export class AccountController {
     await this.tokenService.revoke(token)
     await this.tokenService.create(account)
     return res.status(201).json({
-      token: (await this.accountService.token(account))?.token,
+      token: (await this.accountService.lastToken(account))?.token,
     })
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
   },
   "include": [
     "src/**/*.ts",
+    "AzureCommentsApiDelete/**/*.ts",
     "AzureCommentsApiGet/**/*.ts",
     "AzureCommentsApiPost/**/*.ts",
     "AzureCommentsNotify/**/*.ts",


### PR DESCRIPTION
The idea here is to not have to run the JComments dashboard at all if you only receive a couple of comments per month and more often than not, you get notified about one that evaded the SPAM filter. So you'll save one of your tokens and run the script `./scripts/rmcomment.sh` with a few env vars attached, and the API will delete the spam comment.